### PR TITLE
add hasSelectedInnerBlock hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ apiFetch( {
 
 ## useHasSelectedInnerBlock
 
-Determine wether one of the inner blocks currently is selected.
+Determine whether one of the inner blocks currently is selected.
 
 ### Usage
 ```js

--- a/README.md
+++ b/README.md
@@ -36,3 +36,20 @@ apiFetch( {
     path: `wp/v2/search/?search="${keyword}"&subtype="${postTypes.join(',')}"&type=post`
 } )...
 ```
+
+## useHasSelectedInnerBlock
+
+Determine wether one of the inner blocks currently is selected.
+
+### Usage
+```js
+import { useHasSelectedInnerBlock } from '@10up/block-components';
+
+function BlockEdit( props ) {
+    const hasSelectedInnerBlock = useHasSelectedInnerBlock(props);
+
+    return (
+        <p>This block is currently { hasSelectedInnerBlock ? 'selected' : 'not selected' }.</p>
+    )
+}
+```

--- a/hooks/use-has-selected-inner-block.js
+++ b/hooks/use-has-selected-inner-block.js
@@ -5,7 +5,7 @@ import { useSelect } from '@wordpress/data';
  *
  * @param {WPBlock} selectedBlock Block object of the currently selected block
  * @param {string} clientId Client ID of the block to check
- * @return {boolean} Wether or not a child block is selected
+ * @return {boolean} Whether or not a child block is selected
  */
 function hasSelectedInnerBlock(selectedBlock, clientId) {
 	const { innerBlocks } = useSelect((select) =>

--- a/hooks/use-has-selected-inner-block.js
+++ b/hooks/use-has-selected-inner-block.js
@@ -32,7 +32,7 @@ function hasSelectedInnerBlock(selectedBlock, clientId) {
  * Determine whether one of the inner blocks currently is selected
  *
  * @param {WPBlock} block Block object to with children
- * @return {boolean} wether or not any children are selected.
+ * @return {boolean} whether or not any children are selected.
  */
 export function useHasSelectedInnerBlock(block) {
 	try {

--- a/hooks/use-has-selected-inner-block.js
+++ b/hooks/use-has-selected-inner-block.js
@@ -1,0 +1,47 @@
+import { useSelect } from '@wordpress/data';
+
+/**
+ * check wether the block to check has any children that match the clientID of the selected block
+ *
+ * @param {WPBlock} selectedBlock Block object of the currently selected block
+ * @param {string} clientId Client ID of the block to check
+ * @return {boolean} Wether or not a child block is selected
+ */
+function hasSelectedInnerBlock(selectedBlock, clientId) {
+	const { innerBlocks } = useSelect((select) =>
+		select('core/block-editor').getBlock(clientId),
+	);
+
+	let isChildSelected = false;
+
+	innerBlocks.forEach((innerBlock) => {
+		if (selectedBlock.clientId === innerBlock.clientId) {
+			isChildSelected = true;
+		}
+
+		if (innerBlock.innerBlocks.length) {
+			isChildSelected = hasSelectedInnerBlock(selectedBlock, innerBlock.clientId);
+		}
+	});
+
+	return isChildSelected;
+}
+
+/**
+ * useHasSelectedInnerBlock
+ * Determine wether one of the inner blocks currently is selected
+ *
+ * @param {WPBlock} block Block object to with children
+ * @return {boolean} wether or not any children are selected.
+ */
+export function useHasSelectedInnerBlock(block) {
+	try {
+		const selectedBlock = useSelect((innerSelect) =>
+			innerSelect('core/block-editor').getSelectionStart(),
+		);
+
+		return hasSelectedInnerBlock(selectedBlock, block.clientId);
+	} catch (error) {
+		return false;
+	}
+}

--- a/hooks/use-has-selected-inner-block.js
+++ b/hooks/use-has-selected-inner-block.js
@@ -1,7 +1,7 @@
 import { useSelect } from '@wordpress/data';
 
 /**
- * check wether the block to check has any children that match the clientID of the selected block
+ * check whether the block to check has any children that match the clientID of the selected block
  *
  * @param {WPBlock} selectedBlock Block object of the currently selected block
  * @param {string} clientId Client ID of the block to check

--- a/hooks/use-has-selected-inner-block.js
+++ b/hooks/use-has-selected-inner-block.js
@@ -29,7 +29,7 @@ function hasSelectedInnerBlock(selectedBlock, clientId) {
 
 /**
  * useHasSelectedInnerBlock
- * Determine wether one of the inner blocks currently is selected
+ * Determine whether one of the inner blocks currently is selected
  *
  * @param {WPBlock} block Block object to with children
  * @return {boolean} wether or not any children are selected.

--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 export { ContentPicker } from './components/content-picker';
+export { useHasSelectedInnerBlock } from './hooks/use-has-selected-inner-block';


### PR DESCRIPTION
This also is something that I needed to use several times on projects. There was no real good way of knowing wether a block has selected inner blocks. And this hook allows you to check that. 

```js
import { useHasSelectedInnerBlock } from '@10up/block-components';
function BlockEdit( props ) {
    const hasSelectedInnerBlock = useHasSelectedInnerBlock(props);
    return (
        <p>This block is currently { hasSelectedInnerBlock ? 'selected' : 'not selected' }.</p>
    )
}