### PR TITLE
refactor useHasSelectedInnerBlock to use core function

### DIFF
--- a/hooks/use-has-selected-inner-block.js
+++ b/hooks/use-has-selected-inner-block.js
@@ -1,47 +1,12 @@
 import { useSelect } from '@wordpress/data';
 
 /**
- * check whether the block to check has any children that match the clientID of the selected block
- *
- * @param {WPBlock} selectedBlock Block object of the currently selected block
- * @param {string} clientId Client ID of the block to check
- * @return {boolean} Whether or not a child block is selected
- */
-function hasSelectedInnerBlock(selectedBlock, clientId) {
-	const { innerBlocks } = useSelect((select) =>
-		select('core/block-editor').getBlock(clientId),
-	);
-
-	let isChildSelected = false;
-
-	innerBlocks.forEach((innerBlock) => {
-		if (selectedBlock.clientId === innerBlock.clientId) {
-			isChildSelected = true;
-		}
-
-		if (innerBlock.innerBlocks.length) {
-			isChildSelected = hasSelectedInnerBlock(selectedBlock, innerBlock.clientId);
-		}
-	});
-
-	return isChildSelected;
-}
-
-/**
  * useHasSelectedInnerBlock
  * Determine whether one of the inner blocks currently is selected
  *
- * @param {WPBlock} block Block object to with children
- * @return {boolean} whether or not any children are selected.
+ * @param {Object} {clientId} block props containing the client id
+ * @returns {boolean} wether the block is the ancestor of selected blocks
  */
-export function useHasSelectedInnerBlock(block) {
-	try {
-		const selectedBlock = useSelect((innerSelect) =>
-			innerSelect('core/block-editor').getSelectionStart(),
-		);
-
-		return hasSelectedInnerBlock(selectedBlock, block.clientId);
-	} catch (error) {
-		return false;
-	}
+export function useHasSelectedInnerBlock({clientId}) {
+	return useSelect((select) => select('core/block-editor').hasSelectedInnerBlock(clientId, true));
 }


### PR DESCRIPTION
I just found out that core now has a method in the `core/block-editor` data store to determine wether a block has block selected. So I refactored our component to use the core functionality. 