### PR TITLE
Allow ContentPicker to be used outside editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ function MyComponent( props ) {
 | `maxContentItems`          | `number`   | `1`                   | Max number of items a user can select.
 | `isOrderable`          | `bool`   | `false`                   | When true, will allow the user to order items. Must be used in conjunction with `maxContentItems > 1`
 | `uniqueContentItems`          | `bool`   | `true`                   | Prevent duplicate items from being picked.
-| `excludeCurrentPost`          | `bool`   | `true`                   | Don't allow user to pick the current post.
+| `excludeCurrentPost`          | `bool`   | `true`                   | Don't allow user to pick the current post. Only applicable on the editor screen.
 | `content`          | `array`   | `[]`                   | Array of items to prepopulate picker with. Must be in the format of: `[{id: 1, type: 'post'}, {id: 1, type: 'page'},... ]`. You cannot provide terms and posts to the same picker. Can also take the form `[1, 2, ...]` if only one `contentTypes` is provided.
 
 __NOTE:__ Content picker cannot validate that posts you pass it via `content` prop actually exist. If a post does not exist, it will not render as one of the picked items but will still be passed back as picked items if new items are picked/sorted. Therefore, on save you need to validate that all the picked posts/terms actually exist.

--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -43,7 +43,7 @@ const ContentPicker = ({
 }) => {
 	const [content, setContent] = useState(presetContent);
 
-	const currentPostId = select('core/editor').getCurrentPostId();
+	const currentPostId = select('core/editor')?.getCurrentPostId();
 
 	if (content.length && typeof content[0] !== 'object') {
 		for (let i = 0; i < content.length; i++) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Currently, the `ContentPicker` component can't be used outside the editor because the following line causes an error due to the `core/editor` store not being set up:

https://github.com/10up/block-components/blob/c42de2f3bda7af1920a9fa6b4e1be4e0fd283c0d/components/ContentPicker/index.js#L46

By adding the optional chaining operator to this line, that line can be bypassed if the `core/editor` store is not set up. This makes it possible to use the ContentPicker anywhere else in the WP admin.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

Use ContentPicker in widgets, settings screens, etc.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Allow ContentPicker to be used outside the editor.