### PR TITLE
Content picker: handle nonexistent items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 node_modules
 .vscode

--- a/components/ContentPicker/PickedItem.js
+++ b/components/ContentPicker/PickedItem.js
@@ -10,8 +10,8 @@ import { useEffect } from '@wordpress/element';
 /**
  * PickedItem
  *
- * @param {object} props react props
- * @returns {*} React JSX
+ * @param {Object} props react props
+ * @return {*} React JSX
  */
 
 const DragHandle = sortableHandle(() => (
@@ -45,9 +45,11 @@ const Wrapper = styled('div')`
 	}
 `;
 
-const PickedItem = ({ item, isOrderable, handleItemDelete, sortIndex, mode }) => {
+const PickedItem = ({ item, isOrderable, handleItemDelete, mode }) => {
 	const type = mode === 'post' ? 'postType' : 'taxonomy';
 
+	// This will return undefined while the item data is being fetched. If the item comes back
+	// empty, it will return null, which is handled in the effect below.
 	const preparedItem = useSelect(
 		(select) => {
 			const { getEntityRecord, hasFinishedResolution } = select('core');
@@ -72,7 +74,7 @@ const PickedItem = ({ item, isOrderable, handleItemDelete, sortIndex, mode }) =>
 		[item.id, type],
 	);
 
-	// If `getEntityRecord` did not return an item, pass it to the delete
+	// If `getEntityRecord` did not return an item, pass it to the delete callback.
 	useEffect(() => {
 		if (preparedItem === null) {
 			handleItemDelete(item);
@@ -102,7 +104,7 @@ const PickedItem = ({ item, isOrderable, handleItemDelete, sortIndex, mode }) =>
 			<button
 				type="button"
 				onClick={() => {
-					handleItemDelete(preparedItem, sortIndex);
+					handleItemDelete(preparedItem);
 				}}
 				aria-label={__('Delete item', '10up-block-components')}
 			>
@@ -122,7 +124,6 @@ PickedItem.propTypes = {
 	item: PropTypes.object.isRequired,
 	isOrderable: PropTypes.bool,
 	handleItemDelete: PropTypes.func.isRequired,
-	sortIndex: PropTypes.number.isRequired,
 	mode: PropTypes.string.isRequired,
 };
 

--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import arrayMove from 'array-move';
 import styled from '@emotion/styled';
 import { select } from '@wordpress/data';
-import { useState } from '@wordpress/element'; // eslint-disable-line
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ContentSearch } from '../ContentSearch';
 import SortableList from './SortableList';
@@ -10,9 +10,24 @@ import SortableList from './SortableList';
 const NAMESPACE = '10up-content-picker';
 
 /**
+ * Unfortunately, we had to use !important because on PickedItem we couldn't @emotion/styled css
+ * as it was breaking sortability from react-sortable-hoc
+ */
+const StyleWrapper = styled('div')`
+	& .block-editor-link-control__search-item {
+		border: none !important;
+		cursor: default;
+
+		&:hover {
+			background: transparent;
+		}
+	}
+`;
+
+/**
  * Content Picker
  *
- * @param {Object} props React props
+ * @param {object} props React props
  * @param props.label
  * @param props.mode
  * @param props.contentTypes
@@ -25,7 +40,7 @@ const NAMESPACE = '10up-content-picker';
  * @param props.content
  * @param props.uniqueContentItems
  * @param props.excludeCurrentPost
- * @return {*} React JSX
+ * @returns {*} React JSX
  */
 const ContentPicker = ({
 	label,
@@ -54,55 +69,40 @@ const ContentPicker = ({
 		}
 	}
 
-	function handleSelect(item) {
-		const newContent = [...content];
+	// Run onPickChange callback when content changes.
+	useEffect(() => {
+		onPickChange(content);
+	}, [content, onPickChange]);
 
-		newContent.unshift({
-			id: item.id,
-			type: item.subtype,
-		});
+	const handleSelect = (item) => {
+		setContent((previousContent) => [
+			{
+				id: item.id,
+				type: item.subtype,
+			},
+			...previousContent,
+		]);
+	};
 
-		onPickChange(newContent);
+	const onDeleteItem = (deletedItem) => {
+		setContent((previousContent) => previousContent.filter(({ id }) => id !== deletedItem.id));
+	};
 
-		setContent(newContent);
-	}
+	const excludeItems = useMemo(() => {
+		const items = uniqueContentItems ? [...content] : [];
 
-	function handleItemDelete(item, sortIndex) {
-		const newContent = [...content];
-
-		newContent.splice(sortIndex, 1);
-
-		onPickChange(newContent);
-
-		setContent(newContent);
-	}
-
-	/**
-	 * Unfortunately, we had to use !important because on PickedItem we couldn't @emotion/styled css
-	 * as it was breaking sortability from react-sortable-hoc
-	 */
-	const StyleWrapper = styled('div')`
-		& .block-editor-link-control__search-item {
-			border: none !important;
-			cursor: default;
-
-			&:hover {
-				background: transparent;
-			}
+		if (excludeCurrentPost && currentPostId) {
+			items.push({
+				id: currentPostId,
+			});
 		}
-	`;
 
-	const excludeItems = uniqueContentItems ? [...content] : [];
-
-	if (excludeCurrentPost && currentPostId) {
-		excludeItems.push({
-			id: currentPostId,
-		});
-	}
+		return items;
+	}, [content, currentPostId, excludeCurrentPost, uniqueContentItems]);
 
 	return (
 		<div className={`${NAMESPACE}`}>
-			{!content.length || (content.length && content.length < maxContentItems) ? (
+			{(!content.length || (content.length && content.length < maxContentItems)) && (
 				<ContentSearch
 					placeholder={placeholder}
 					label={label}
@@ -110,8 +110,8 @@ const ContentPicker = ({
 					onSelectItem={handleSelect}
 					contentTypes={contentTypes}
 				/>
-			) : null}
-			{content.length ? (
+			)}
+			{content?.length && (
 				<StyleWrapper>
 					<span
 						style={{
@@ -126,19 +126,17 @@ const ContentPicker = ({
 					<SortableList
 						items={content}
 						useDragHandle
+						handleItemDelete={onDeleteItem}
 						isOrderable={isOrderable}
 						mode={mode}
-						handleItemDelete={handleItemDelete}
 						onSortEnd={({ oldIndex, newIndex }) => {
 							const newContent = [...arrayMove(content, oldIndex, newIndex)];
-
-							onPickChange(newContent);
 
 							setContent(newContent);
 						}}
 					/>
 				</StyleWrapper>
-			) : null}
+			)}
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This resolves #26 by running the delete callback on any items that are not returned by `getEntityRecord`. I also did a little tangential cleanup, which I'll comment on inline.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

This change only applies to items that have been deleted completely. So e.g. draft posts or posts that are in trash are still returned. We might want to do something to handle those cases, maybe in a separate issue.

### Benefits

<!-- What benefits will be realized by the code change? -->

When a previously picked item is nonexistent, the content picker will no longer behave as if there are more items than there really are.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

When using this branch, use the content picker in a context where its picked items are saved and loaded from the database (e.g., in post meta). Pick an item and save. Delete the item completely. Reload the content picker and verify that the `maxContentItems` works as expected.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#26

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Add handling of nonexistent items in the ContentPicker component.