### PR TITLE
Fix/contentpicker terms

### DIFF
--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -109,6 +109,7 @@ const ContentPicker = ({
 					excludeItems={excludeItems}
 					onSelectItem={handleSelect}
 					contentTypes={contentTypes}
+					mode={mode}
 				/>
 			) : null}
 			{content.length ? (

--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -59,7 +59,7 @@ const ContentPicker = ({
 
 		newContent.unshift({
 			id: item.id,
-			type: item.subtype,
+			type: 'subtype' in item ? item.subtype : item.type,
 		});
 
 		onPickChange(newContent);


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

* Passes `mode` to `ContentSearch` from the `ContentPicker` component.
* Falls back to `type` if `subtype` isn't available within `ContentPicker`

### Benefits

Fixes the `ContentPicker` component when using terms

### Possible Drawbacks

None

### Verification Process

Tested on a local project

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

* #36 
* #37 

### Changelog Entry

- Fixed compatibility issue when using terms with the ContentPicker component