### PR TITLE
Fix 0 showing up in place of empty content picker results

### DIFF
--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -111,7 +111,7 @@ const ContentPicker = ({
 					contentTypes={contentTypes}
 				/>
 			)}
-			{content?.length && (
+			{Boolean(content?.length) > 0 && (
 				<StyleWrapper>
 					<span
 						style={{


### PR DESCRIPTION
This fixes the issue shown in the screenshot below -- the number "0" was showing up when content picker results were empty.

![Screen Shot 2021-08-03 at 12 12 03 PM](https://user-images.githubusercontent.com/9020968/128063625-e402639e-9552-4305-9edc-e397b5bae08a.png)
