### PR TITLE
Fix drag handle icon size

### DIFF
--- a/components/ContentPicker/PickedItem.js
+++ b/components/ContentPicker/PickedItem.js
@@ -16,7 +16,7 @@ import { useEffect } from '@wordpress/element';
 
 const DragHandle = sortableHandle(() => (
 	<svg
-		style={{ marginRight: '5px', cursor: 'grab' }}
+		style={{ marginRight: '5px', cursor: 'grab', flexShrink: 0 }}
 		width="18"
 		height="18"
 		xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

This PR aims to fix this issue: https://github.com/10up/block-components/issues/33

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

1. Add the following code to a custom block:
```js
import { ContentPicker } from '@10up/block-components';

...

<ContentPicker
  onPickChange={(pickedContent) => {
    console.log(pickedContent);
  }}
  isOrderable
  maxContentItems={3}
  mode="post"
  label="Please select a Post or Page:"
  contentTypes={['post', 'page']}
/>
```
2. Add a few posts and resize the window down
3. The drag handle size should remain the same as full-width window

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

- Fix drag handle size
