### PR TITLE
ContentSearch: Making sure cached content gets filtered too

### DIFF
--- a/components/ContentSearch/index.js
+++ b/components/ContentSearch/index.js
@@ -82,10 +82,8 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 					return;
 				}
 
-				const newResults = filterResults(results);
-				searchCache[searchQuery] = newResults;
-
-				setSearchResults(newResults);
+				searchCache[searchQuery] = results;
+				setSearchResults(filterResults(results));
 				setIsLoading(false);
 			});
 		}

--- a/components/ContentSearch/index.js
+++ b/components/ContentSearch/index.js
@@ -40,6 +40,18 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 		onSelectItem(item);
 	}
 
+	function filterResults(results) {
+		return results.filter((result) => {
+			let keep = true;
+
+			if (excludeItems.length) {
+				keep = excludeItems.every((item) => item.id !== result.id);
+			}
+
+			return keep;
+		});
+	}
+
 	const hasSearchString = !!searchString.length;
 	const hasSearchResults = !!searchResults.length;
 
@@ -60,7 +72,7 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 		)}&type=${mode}&_embed`;
 
 		if (searchCache[searchQuery]) {
-			setSearchResults(searchCache[searchQuery]);
+			setSearchResults(filterResults(searchCache[searchQuery]));
 			setIsLoading(false);
 		} else {
 			apiFetch({
@@ -70,20 +82,7 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 					return;
 				}
 
-				const newResults = results.filter((result) => {
-					let keep = true;
-
-					if (excludeItems.length) {
-						excludeItems.forEach((item) => {
-							if (item.id === result.id) {
-								keep = false;
-							}
-						});
-					}
-
-					return keep;
-				});
-
+				const newResults = filterResults(results);
 				searchCache[searchQuery] = newResults;
 
 				setSearchResults(newResults);


### PR DESCRIPTION
### Description of the Change

On `ContentSearch`, when there's a cached query (not repeated), items were served as is which wouldn't prevent repeated items to be added on a single swift.

This also slightly improves the efficiency of the filter since it uses `every` instead of `forEach` which will break as soon as the filter fails.

### Checklist:

- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Fixes #46 

### Changelog Entry

* Fixes filtering of `excludeItems` on `ContentSearch` which wasn't preventing a cached query from showing results that were already selected.
