### PR TITLE
Add UrlPicker component

### DIFF
--- a/components/UrlPicker/index.js
+++ b/components/UrlPicker/index.js
@@ -14,9 +14,8 @@
    __experimentalLinkControl as LinkControl,
  } from '@wordpress/block-editor';
  import { rawShortcut } from '@wordpress/keycodes';
- import { debounce } from 'lodash';
- import { searchablePostTypes } from './helper';
- 
+ import { debounce } from 'lodash'; 
+
  export default function UrlPicker({
    url,
    opensInNewTab,
@@ -31,6 +30,12 @@
  }) {
    const [isURLPickerOpen, setIsURLPickerOpen] = useState(false);
    const [selected, setSelected] = useState(false);
+
+   const searchablePostTypes = [
+		'post',
+		'page',
+	];
+
    const openLinkControl = () => {
 	 setIsURLPickerOpen(true);
 	 return false; // prevents default behaviour for event

--- a/components/UrlPicker/index.js
+++ b/components/UrlPicker/index.js
@@ -1,0 +1,106 @@
+/**
+ * WordPress dependencies
+ */
+ import { __ } from '@wordpress/i18n';
+ import { useState } from '@wordpress/element';
+ import {
+   KeyboardShortcuts,
+   Popover,
+   Button,
+   Tooltip,
+ } from '@wordpress/components';
+ import {
+   PlainText,
+   __experimentalLinkControl as LinkControl,
+ } from '@wordpress/block-editor';
+ import { rawShortcut } from '@wordpress/keycodes';
+ import { debounce } from 'lodash';
+ import { searchablePostTypes } from './helper';
+ 
+ export default function UrlPicker({
+   url,
+   opensInNewTab,
+   onLinkChange,
+   onTextChange,
+   placeholder,
+   text,
+   isBlockSelected,
+   title,
+   linkOptional,
+   ...extraProps
+ }) {
+   const [isURLPickerOpen, setIsURLPickerOpen] = useState(false);
+   const [selected, setSelected] = useState(false);
+   const openLinkControl = () => {
+	 setIsURLPickerOpen(true);
+	 return false; // prevents default behaviour for event
+   };
+ 
+   const linkControl = isURLPickerOpen && (
+	 <Popover
+	   position="bottom center"
+	   onClose={() => {
+		 setIsURLPickerOpen(false);
+		 setSelected(false);
+	   }}
+	 >
+	   {title && <h4 className="tenup-popover-title">{title}</h4>}
+	   <LinkControl
+		 className="wp-block-navigation-link__inline-link-input"
+		 value={{ url, opensInNewTab }}
+		 onChange={onLinkChange}
+		 suggestionsQuery={{
+		   subtype: searchablePostTypes.join(','),
+		 }}
+	   />
+	 </Popover>
+   );
+   return (
+	 <div className="tenup-url-picker">
+	   {selected && (
+		 <KeyboardShortcuts
+		   bindGlobal
+		   shortcuts={{
+			 [rawShortcut.primary('k')]: openLinkControl,
+		   }}
+		 />
+	   )}
+	   {linkControl}
+	   <PlainText
+		 value={text}
+		 onChange={(value) => {
+		   onTextChange(value.replace(/[\r\n\t]+/gm, ' '));
+		 }}
+		 placeholder={placeholder}
+		 keepPlaceholderOnFocus
+		 onFocus={debounce(() => {
+		   setSelected(true);
+		 }, 100)}
+		 onBlur={debounce(() => {
+		   setSelected(false);
+		 }, 100)}
+		 {...extraProps}
+	   />
+ 
+	   <Button
+		 className={`
+		 link-toggle is-small
+		 ${selected && 'active'}
+		 ${isBlockSelected || 'hidden'}
+		 `}
+		 icon={<span className="dashicons dashicons-admin-links"></span>}
+		 onClick={openLinkControl}
+	   />
+ 
+	   {!linkOptional && text && !url && (
+		 <Tooltip text={__('This item is missing a link', '10up-block-components')}>
+		   <span
+			 tabIndex={0}
+			 className="missing-link dashicons dashicons-warning"
+		   />
+		 </Tooltip>
+	   )}
+	 </div>
+   );
+ }
+ 


### PR DESCRIPTION
This PR likely still needs some code styling to match the rest of the components, as of this writing it is currently just fully pulled over from another project with that name replaced.

### Description of the Change
Adding UrlPicker component as used on multiple projects. Code is largely from @dinhtungdu. The UrlPicker is currently a PlainText component with button icons to set the URL via popover and to warn when a URL is missing. The button icon is used rather than a toolbar button in order to disambiguate when there are multiple links within a block.

### Alternate Designs
Takes cues from how button links work, minus the toolbar because no formatting options.

### Benefits
Reusable component particularly handy for lists of links or CTAs.

### Possible Drawbacks
Not sure.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
