### PR TITLE
Feature/content search improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ function MyComponent( props ) {
 | `uniqueContentItems`          | `bool`   | `true`                   | Prevent duplicate items from being picked.
 | `excludeCurrentPost`          | `bool`   | `true`                   | Don't allow user to pick the current post. Only applicable on the editor screen.
 | `content`          | `array`   | `[]`                   | Array of items to prepopulate picker with. Must be in the format of: `[{id: 1, type: 'post'}, {id: 1, type: 'page'},... ]`. You cannot provide terms and posts to the same picker. Can also take the form `[1, 2, ...]` if only one `contentTypes` is provided.
-| `perPage`           | `number`   | `10`               | Number of items to show during search
+| `perPage`           | `number`   | `50`               | Number of items to show during search
 __NOTE:__ Content picker cannot validate that posts you pass it via `content` prop actually exist. If a post does not exist, it will not render as one of the picked items but will still be passed back as picked items if new items are picked/sorted. Therefore, on save you need to validate that all the picked posts/terms actually exist.
 
 The `contentTypes` will get used in a Rest Request to the `search` endpoint as the `subtypes`:
@@ -87,7 +87,7 @@ function MyComponent( props ) {
 | `placeholder`    | `string`   | `''`                   | Renders placeholder text inside the Search Field.                      |
 | `contentTypes`      | `array`    | `[ 'post', 'page' ]` | Names of the post types or taxonomies that should get searched                       |
 | `excludeItems`      | `array`    | `[ { id: 1, type: 'post' ]` | Items to exclude from search |
-| `perPage`           | `number`   | `10`               | Number of items to show during search
+| `perPage`           | `number`   | `50`               | Number of items to show during search
 
 
 ## useHasSelectedInnerBlock

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ function MyComponent( props ) {
 | `uniqueContentItems`          | `bool`   | `true`                   | Prevent duplicate items from being picked.
 | `excludeCurrentPost`          | `bool`   | `true`                   | Don't allow user to pick the current post. Only applicable on the editor screen.
 | `content`          | `array`   | `[]`                   | Array of items to prepopulate picker with. Must be in the format of: `[{id: 1, type: 'post'}, {id: 1, type: 'page'},... ]`. You cannot provide terms and posts to the same picker. Can also take the form `[1, 2, ...]` if only one `contentTypes` is provided.
-
+| `perPage`           | `number`   | `10`               | Number of items to show during search
 __NOTE:__ Content picker cannot validate that posts you pass it via `content` prop actually exist. If a post does not exist, it will not render as one of the picked items but will still be passed back as picked items if new items are picked/sorted. Therefore, on save you need to validate that all the picked posts/terms actually exist.
 
 The `contentTypes` will get used in a Rest Request to the `search` endpoint as the `subtypes`:
@@ -87,7 +87,7 @@ function MyComponent( props ) {
 | `placeholder`    | `string`   | `''`                   | Renders placeholder text inside the Search Field.                      |
 | `contentTypes`      | `array`    | `[ 'post', 'page' ]` | Names of the post types or taxonomies that should get searched                       |
 | `excludeItems`      | `array`    | `[ { id: 1, type: 'post' ]` | Items to exclude from search |
-
+| `perPage`           | `number`   | `10`               | Number of items to show during search
 
 
 ## useHasSelectedInnerBlock
@@ -158,9 +158,9 @@ const ExampleBockEdit = ({ className }) => {
 	}
 	return (
 		<div className={className}>
-			
+
 				{data &&( <div>{data.title.rendered}</div>)}
-			
+
 			<button type="button" onClick={invalidateRequest}>
 				Refresh list
 			</button>

--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -55,6 +55,7 @@ const ContentPicker = ({
 	content: presetContent,
 	uniqueContentItems,
 	excludeCurrentPost,
+	perPage
 }) => {
 	const [content, setContent] = useState(presetContent);
 
@@ -110,6 +111,7 @@ const ContentPicker = ({
 					onSelectItem={handleSelect}
 					contentTypes={contentTypes}
 					mode={mode}
+					perPage={perPage}
 				/>
 			)}
 			{Boolean(content?.length) > 0 && (
@@ -151,6 +153,7 @@ ContentPicker.defaultProps = {
 	contentTypes: ['post', 'page'],
 	placeholder: '',
 	content: [],
+	perPage: 10,
 	maxContentItems: 1,
 	uniqueContentItems: true,
 	isOrderable: false,
@@ -172,6 +175,7 @@ ContentPicker.propTypes = {
 	uniqueContentItems: PropTypes.bool,
 	excludeCurrentPost: PropTypes.bool,
 	maxContentItems: PropTypes.number,
+	perPage: PropTypes.number,
 };
 
 export { ContentPicker };

--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -153,7 +153,7 @@ ContentPicker.defaultProps = {
 	contentTypes: ['post', 'page'],
 	placeholder: '',
 	content: [],
-	perPage: 10,
+	perPage: 50,
 	maxContentItems: 1,
 	uniqueContentItems: true,
 	isOrderable: false,

--- a/components/ContentSearch/index.js
+++ b/components/ContentSearch/index.js
@@ -9,7 +9,7 @@ const NAMESPACE = '10up-content-search';
 
 const searchCache = {};
 
-const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, excludeItems }) => {
+const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, excludeItems, perPage }) => {
 	const [searchString, setSearchString] = useState('');
 	const [searchResults, setSearchResults] = useState([]);
 	const [isLoading, setIsLoading] = useState(false);
@@ -77,9 +77,10 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 
 		const searchQuery = `wp/v2/search/?search=${keyword}&subtype=${contentTypes.join(
 			',',
-		)}&type=${mode}&_embed`;
+		)}&type=${mode}&_embed&per_page=${perPage}`;
 
 		if (searchCache[searchQuery]) {
+			console.log('Setting search results for ' + keyword);
 			setSearchResults(filterResults(searchCache[searchQuery]));
 			setIsLoading(false);
 		} else {
@@ -91,8 +92,12 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 				}
 
 				searchCache[searchQuery] = results;
-				setSearchResults(filterResults(results));
-				setIsLoading(false);
+
+				if (keyword === searchString) {
+					console.log('Setting search results for ' + keyword);
+					setSearchResults(filterResults(results));
+					setIsLoading(false);
+				}
 			});
 		}
 	};
@@ -164,6 +169,7 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 ContentSearch.defaultProps = {
 	contentTypes: ['post', 'page'],
 	placeholder: '',
+	perPage: 10,
 	label: '',
 	excludeItems: [],
 	mode: 'post',
@@ -179,6 +185,7 @@ ContentSearch.propTypes = {
 	placeholder: PropTypes.string,
 	excludeItems: PropTypes.array,
 	label: PropTypes.string,
+	perPage: PropTypes.number
 };
 
 export { ContentSearch };

--- a/components/ContentSearch/index.js
+++ b/components/ContentSearch/index.js
@@ -92,7 +92,7 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 
 		const searchQuery = `wp/v2/search/?search=${keyword}&subtype=${contentTypes.join(
 			',',
-		)}&type=${mode}&_embed&per_page=${perPage}`;
+		)}&type=${mode}&_embed&per_page=50`;
 
 		if (searchCache[searchQuery]) {
 			abortControllerRef.current = null;
@@ -151,6 +151,8 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 						marginLeft: '0',
 						paddingLeft: '0',
 						listStyle: 'none',
+						maxHeight: '350px',
+						overflowY: 'scroll'
 					}}
 				>
 					{isLoading && <Spinner />}
@@ -194,7 +196,7 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 ContentSearch.defaultProps = {
 	contentTypes: ['post', 'page'],
 	placeholder: '',
-	perPage: 10,
+	perPage: 50,
 	label: '',
 	excludeItems: [],
 	mode: 'post',

--- a/components/ContentSearch/index.js
+++ b/components/ContentSearch/index.js
@@ -4,8 +4,10 @@ import { useState, useRef, useEffect } from '@wordpress/element'; // eslint-disa
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import SearchItem from './SearchItem';
+/** @jsx jsx */
+import { jsx, css } from '@emotion/react';
 
-const NAMESPACE = '10up-content-search';
+const NAMESPACE = 'tenup-content-search';
 
 const searchCache = {};
 
@@ -133,6 +135,12 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 		};
 	}, []);
 
+	const listCSS = css`
+		/* stylelint-disable */
+		max-height: 350px;
+		overflow-y: scroll;
+	`;
+
 	return (
 		<NavigableMenu onNavigate={handleOnNavigate} orientation="vertical">
 			<TextControl
@@ -151,9 +159,8 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 						marginLeft: '0',
 						paddingLeft: '0',
 						listStyle: 'none',
-						maxHeight: '350px',
-						overflowY: 'scroll'
 					}}
+					css={listCSS}
 				>
 					{isLoading && <Spinner />}
 					{!isLoading && !hasSearchResults && (

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "10up Components built for the WordPress Block Editor.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR does a few things:

1. Makes the content search show by default 50 items which can be overridden
2. Sets a max height/scroll on content search which can be overridden.
3. Fixes a bug where competing content search AJAX requests would override each other depending on which one finished first.