### PR TITLE
Make sure the page is a dynamic property

### DIFF
--- a/components/ContentSearch/index.js
+++ b/components/ContentSearch/index.js
@@ -94,7 +94,7 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 
 		const searchQuery = `wp/v2/search/?search=${keyword}&subtype=${contentTypes.join(
 			',',
-		)}&type=${mode}&_embed&per_page=50`;
+		)}&type=${mode}&_embed&per_page=${perPage}`;
 
 		if (searchCache[searchQuery]) {
 			abortControllerRef.current = null;


### PR DESCRIPTION
### Description of the Change

Remove the hardcoded value 50 from the URL and use the provided property instead.


<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

The `50` was hardcoded and not using the dynamic property instead for the `ContentSearch` component.


