### PR TITLE
fix/23: duplicate key error

### DIFF
--- a/components/ContentPicker/PickedItem.js
+++ b/components/ContentPicker/PickedItem.js
@@ -54,14 +54,31 @@ const PickedItem = ({ item, isOrderable, handleItemDelete, mode }) => {
 		(select) => {
 			const { getEntityRecord, hasFinishedResolution } = select('core');
 
-			const getEntityRecordParameters = [type, item.type, item.id];
+			let itemId = item.id;
+
+			if (item?.duplicateOf === undefined) {
+				itemId = item.id;
+			} else if (item.duplicateOf > 0) {
+				itemId = item.duplicateOf;
+			}
+
+			const getEntityRecordParameters = [type, item.type, itemId];
+
 			const result = getEntityRecord(...getEntityRecordParameters);
 
 			if (result) {
+				let resultId = result.id;
+
+				if (item?.duplicateOf === undefined) {
+					resultId = result.id;
+				} else if (item.duplicateOf > 0) {
+					resultId = item.id;
+				}
+
 				return {
 					title: mode === 'post' ? result.title.rendered : result.name,
 					url: result.link,
-					id: result.id,
+					id: resultId,
 				};
 			}
 


### PR DESCRIPTION
Closes #23 

### Description of the Change
As per the conversation in the issue, instead of disallowing multiple items, error thrown for duplicate keys has been fixed.

The fix implements generation of unique key outside the loop because sorting/re-ordering items will not sort the keys for duplicate posts if they're adjacent to each other.


### Verification Process
Follow the steps in the issue and additionally set the following 2 props:
- `maxContentItems={ 6 }`
- `uniqueContentItems={ false }`

### Screencast

https://user-images.githubusercontent.com/17757960/138648303-5ebe6bc2-825b-4e62-a7e1-0a7ccfc312ae.mov



<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.



### Changelog Entry
Fix: duplicate keys error for duplicate content items.
