### PR TITLE
SearchItem - Add tooltip on hover

### DIFF
--- a/components/ContentSearch/SearchItem.js
+++ b/components/ContentSearch/SearchItem.js
@@ -1,7 +1,24 @@
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
-import { Button, TextHighlight } from '@wordpress/components';
+import { Button, TextHighlight, Tooltip } from '@wordpress/components';
+
+const ButtonStyled = styled(Button)`
+	&:hover {
+		/* Add opacity background to support future color changes */
+		/* Reduce background from #ddd to 0.05 for text contrast  */
+		background-color: rgba(0, 0, 0, 0.05);
+
+		.block-editor-link-control__search-item-type {
+			color: black;
+		}
+	}
+
+	.block-editor-link-control__search-item-type {
+		background-color: rgba(0, 0, 0, 0.05);
+	}
+`;
 
 /**
  * SearchItem
@@ -18,43 +35,45 @@ const SearchItem = ({ suggestion, onClick, searchTerm, isSelected, id, contentTy
 	const showType = suggestion.type && contentTypes.length > 1;
 
 	return (
-		<Button
-			id={id}
-			onClick={onClick}
-			className={`block-editor-link-control__search-item is-entity ${
-				isSelected && 'is-selected'
-			}`}
-			style={{
-				borderRadius: '0',
-				boxSizing: 'border-box',
-			}}
-		>
-			<span className="block-editor-link-control__search-item-header">
-				<span
-					className="block-editor-link-control__search-item-title"
-					style={{
-						paddingRight: !showType ? 0 : null,
-					}}
-				>
-					<TextHighlight text={decodeEntities(suggestion.title)} highlight={searchTerm} />
+		<Tooltip text={decodeEntities(suggestion.title)}>
+			<ButtonStyled
+				id={id}
+				onClick={onClick}
+				className={`block-editor-link-control__search-item is-entity ${
+					isSelected && 'is-selected'
+				}`}
+				style={{
+					borderRadius: '0',
+					boxSizing: 'border-box',
+				}}
+			>
+				<span className="block-editor-link-control__search-item-header">
+					<span
+						className="block-editor-link-control__search-item-title"
+						style={{
+							paddingRight: !showType ? 0 : null,
+						}}
+					>
+						<TextHighlight text={decodeEntities(suggestion.title)} highlight={searchTerm} />
+					</span>
+					<span
+						aria-hidden
+						className="block-editor-link-control__search-item-info"
+						style={{
+							paddingRight: !showType ? 0 : null,
+						}}
+					>
+						{filterURLForDisplay(safeDecodeURI(suggestion.url)) || ''}
+					</span>
 				</span>
-				<span
-					aria-hidden
-					className="block-editor-link-control__search-item-info"
-					style={{
-						paddingRight: !showType ? 0 : null,
-					}}
-				>
-					{filterURLForDisplay(safeDecodeURI(suggestion.url)) || ''}
-				</span>
-			</span>
-			{showType && (
-				<span className="block-editor-link-control__search-item-type">
-					{/* Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label. */}
-					{suggestion.type === 'post_tag' ? 'tag' : suggestion.type}
-				</span>
-			)}
-		</Button>
+				{showType && (
+					<span className="block-editor-link-control__search-item-type">
+						{/* Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label. */}
+						{suggestion.type === 'post_tag' ? 'tag' : suggestion.type}
+					</span>
+				)}
+			</ButtonStyled>
+		</Tooltip>
 	);
 };
 

--- a/components/ContentSearch/index.js
+++ b/components/ContentSearch/index.js
@@ -138,7 +138,7 @@ const ContentSearch = ({ onSelectItem, placeholder, label, contentTypes, mode, e
 	const listCSS = css`
 		/* stylelint-disable */
 		max-height: 350px;
-		overflow-y: scroll;
+		overflow-y: auto;
 	`;
 
 	return (


### PR DESCRIPTION
Fixes #17 

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Added Gutenberg-native tooltip on hover. Changed overflow-y to auto instead of scroll to hide the scrollbar when there is no need to scroll (few items to show)

Also "post" is not highlighted on hover now to increase contrast ratio

![](https://i.imgur.com/X3AAFWw.png)

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Still, the titles are not fully visible. A potential solution would be to have a prop that says "Show full titles".
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
