### PR TITLE
Fix duplicate keys issue in content picker. Addresses #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ function MyComponent( props ) {
 | `isOrderable`          | `bool`   | `false`                   | When true, will allow the user to order items. Must be used in conjunction with `maxContentItems > 1`
 | `uniqueContentItems`          | `bool`   | `true`                   | Prevent duplicate items from being picked.
 | `excludeCurrentPost`          | `bool`   | `true`                   | Don't allow user to pick the current post. Only applicable on the editor screen.
-| `content`          | `array`   | `[]`                   | Array of items to prepopulate picker with. Must be in the format of: `[{id: 1, type: 'post'}, {id: 1, type: 'page'},... ]`. You cannot provide terms and posts to the same picker. Can also take the form `[1, 2, ...]` if only one `contentTypes` is provided.
+| `content`          | `array`   | `[]`                   | Array of items to prepopulate picker with. Must be in the format of: `[{id: 1, type: 'post', uuid: '...',}, {id: 1, uuid: '...', type: 'page'},... ]`. You cannot provide terms and posts to the same picker. `uuid` was added as of version 1.5.0. It is only used as the React component list key in the admin. If it is not included, `id` will be used which will cause errors if you select the same post twice.
 | `perPage`           | `number`   | `50`               | Number of items to show during search
 __NOTE:__ Content picker cannot validate that posts you pass it via `content` prop actually exist. If a post does not exist, it will not render as one of the picked items but will still be passed back as picked items if new items are picked/sorted. Therefore, on save you need to validate that all the picked posts/terms actually exist.
 

--- a/components/ContentPicker/PickedItem.js
+++ b/components/ContentPicker/PickedItem.js
@@ -58,11 +58,17 @@ const PickedItem = ({ item, isOrderable, handleItemDelete, mode }) => {
 			const result = getEntityRecord(...getEntityRecordParameters);
 
 			if (result) {
-				return {
+				const newItem = {
 					title: mode === 'post' ? result.title.rendered : result.name,
 					url: result.link,
 					id: result.id,
 				};
+
+				if (item.uuid) {
+					newItem.uuid = item.uuid;
+				}
+
+				return newItem;
 			}
 
 			if (hasFinishedResolution('getEntityRecord', getEntityRecordParameters)) {

--- a/components/ContentPicker/SortableList.js
+++ b/components/ContentPicker/SortableList.js
@@ -10,10 +10,11 @@ const SortableList = SortableContainer(({ items, isOrderable, handleItemDelete, 
 					'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif',
 			}}
 		>
-			{items.map((item, index) => (
-				<ItemComponent
+			{items.map((item, index) => {
+				const itemKey = item.uuid ? item.uuid : item.id;
+				return <ItemComponent
 					isOrderable={isOrderable && items.length > 1 ? isOrderable : false}
-					key={`item-${item.id}`}
+					key={`item-${itemKey}`}
 					index={index}
 					handleItemDelete={handleItemDelete}
 					sortIndex={index}
@@ -21,7 +22,7 @@ const SortableList = SortableContainer(({ items, isOrderable, handleItemDelete, 
 					mode={mode}
 					totalItems={items.length}
 				/>
-			))}
+			})}
 		</div>
 	);
 });

--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -6,6 +6,7 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ContentSearch } from '../ContentSearch';
 import SortableList from './SortableList';
+import { v4 as uuidv4 } from 'uuid';
 
 const NAMESPACE = '10up-content-picker';
 
@@ -61,6 +62,10 @@ const ContentPicker = ({
 
 	const currentPostId = select('core/editor')?.getCurrentPostId();
 
+	/**
+	 * This legacy code allows you to pass in only IDs to content like [ 1, 4, 5 ].
+	 * This really shouldn't be done as of version 1.5.0.
+	 */
 	if (content.length && typeof content[0] !== 'object') {
 		for (let i = 0; i < content.length; i++) {
 			content[i] = {
@@ -79,6 +84,7 @@ const ContentPicker = ({
 		setContent((previousContent) => [
 			{
 				id: item.id,
+				uuid: uuidv4(),
 				type: 'subtype' in item ? item.subtype : item.type,
 			},
 			...previousContent,
@@ -86,7 +92,15 @@ const ContentPicker = ({
 	};
 
 	const onDeleteItem = (deletedItem) => {
-		setContent((previousContent) => previousContent.filter(({ id }) => id !== deletedItem.id));
+		setContent((previousContent) => {
+			return previousContent.filter(({ id, uuid }) => {
+				if (deletedItem.uuid) {
+					return uuid !== deletedItem.uuid;
+				} else {
+					return id !== deletedItem.id;
+				}
+			});
+		});
 	};
 
 	const excludeItems = useMemo(() => {
@@ -94,7 +108,7 @@ const ContentPicker = ({
 
 		if (excludeCurrentPost && currentPostId) {
 			items.push({
-				id: currentPostId,
+				id: currentPostId
 			});
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@10up/block-components",
-  "version": "1.2.0",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20007,9 +20007,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@emotion/styled": "^11.0.0",
     "array-move": "^3.0.1",
     "prop-types": "^15.7.2",
-    "react-sortable-hoc": "^1.11.0"
+    "react-sortable-hoc": "^1.11.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "10up-toolkit": "^1.0.6"


### PR DESCRIPTION
Addresses #23. Creates a unique key for each picked post using the `uuid` package. This is an alternative to #54