### PR TITLE
Fix: Link Component Popover state

### DIFF
--- a/components/Link/index.js
+++ b/components/Link/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
@@ -9,15 +8,16 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useRef, Fragment } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { Popover, Icon, Tooltip } from '@wordpress/components';
-import { isKeyboardEvent, ENTER, ESCAPE } from '@wordpress/keycodes';
 import {
 	__experimentalLinkControl as LinkControl,
-	useBlockProps,
 	RichText,
 	useBlockEditContext,
 } from '@wordpress/block-editor';
+
+import classNames from 'classnames';
+import { useOnClickOutside } from '../../hooks/use-on-click-outside';
 
 /**
  * Given the Link block's type attribute, return the query params to give to
@@ -63,7 +63,7 @@ const LinkOutput = styled(RichText)`
 	gap: 0.5em;
 	text-decoration: underline;
 
-	/* This  holds the text URL input */
+	/* This holds the text URL input */
 	& > div {
 		text-decoration: underline;
 	}
@@ -97,6 +97,7 @@ const LinkOutput = styled(RichText)`
  * @param {Function} props.onTextChange 				Callback when the link's text is changed
  * @param {string} props.kind 							Page or Post
  * @param {string} props.placeholder 					Text visible before actual value is inserted
+ * @param {string} props.className 					    html class to be applied to the anchor element
  *
  * @returns {JSX}
  */
@@ -109,11 +110,16 @@ const Link = ({
 	onTextChange,
 	kind,
 	placeholder,
+	className,
 }) => {
 	const ref = useRef();
 	const [isLinkOpen, setIsLinkOpen] = useState(false);
 	const [isValid, setIsValid] = useState(false);
 	const { isSelected } = useBlockEditContext();
+	const openPopover = () => setIsLinkOpen(true);
+	const closePopover = () => setIsLinkOpen(false);
+
+	const popoverRef = useOnClickOutside(closePopover);
 
 	const link = {
 		url,
@@ -121,26 +127,12 @@ const Link = ({
 		title: value, // don't allow HTML to display inside the <LinkControl>
 	};
 
-	const blockProps = useBlockProps({
-		ref,
-		className: classnames('tenup-block-components-link', {
-			'is-editing': isSelected,
-			'has-link': !!url,
-		}),
-	});
-
-	if (!url) {
-		blockProps.onClick = () => setIsLinkOpen(true);
-	}
-
 	/**
 	 * The hook shouldn't be necessary but due to a focus loss happening
-	 * when selecting a suggestion in the link popover, we force close on block unselection.
+	 * when selecting a suggestion in the link popover, we force close on block un-selection.
 	 */
 	useEffect(() => {
-		if (!isSelected) {
-			setIsLinkOpen(false);
-		}
+		if (!isSelected) closePopover();
 	}, [isSelected]);
 
 	/**
@@ -155,21 +147,17 @@ const Link = ({
 	return (
 		<>
 			<LinkOutput
-				// eslint-disable-next-line react/jsx-props-no-spreading
-				{...blockProps}
 				tagName="a"
 				identifier="label"
-				className="tenup-block-components-link__label"
+				className={classNames('tenup-block-components-link__label', className)}
 				value={value}
 				onChange={onTextChange}
 				aria-label={__('Link text', '10up-block-components')}
 				placeholder={placeholder}
-				withoutInteractiveFormatting
 				__unstablePastePlainText
 				allowedFormats={['core/bold', 'core/italic', 'core/strikethrough']}
-				onClick={() => {
-					setIsLinkOpen(true);
-				}}
+				onFocusCapture={openPopover}
+				ref={ref}
 			/>
 
 			{!isValid && (
@@ -181,19 +169,26 @@ const Link = ({
 			{isLinkOpen && (
 				<Popover
 					position="top center"
-					onClose={() => setIsLinkOpen(false)}
 					anchorRef={ref.current}
+					ref={popoverRef}
 					focusOnMount={false}
+					noArrow={false}
 				>
 					<LinkControl
 						hasTextControl
-						className="tenup-block-components-link__link-control"
+						className="mconnect-block-components-link__link-control"
 						value={link}
 						showInitialSuggestions
 						noDirectEntry={!!type}
 						noURLSuggestion={!!type}
 						suggestionsQuery={getSuggestionsQuery(type, kind)}
 						onChange={onLinkChange}
+						settings={[
+							{
+								id: 'opensInNewTab',
+								title: __('Open in new tab', '10up-block-components'),
+							},
+						]}
 					/>
 				</Popover>
 			)}
@@ -202,21 +197,23 @@ const Link = ({
 };
 
 Link.defaultProps = {
+	value: undefined,
+	url: undefined,
+	className: undefined,
 	type: '',
 	kind: '',
-
 	placeholder: __('Link text ...', '10up-block-components'),
 };
 
 Link.propTypes = {
-	value: PropTypes.string.isRequired,
-	url: PropTypes.string.isRequired,
+	value: PropTypes.string,
+	url: PropTypes.string,
 	onLinkChange: PropTypes.func.isRequired,
 	onTextChange: PropTypes.func.isRequired,
 	opensInNewTab: PropTypes.bool.isRequired,
-
 	type: PropTypes.string,
 	kind: PropTypes.string,
+	className: PropTypes.string,
 	placeholder: PropTypes.string,
 };
 

--- a/components/Link/index.js
+++ b/components/Link/index.js
@@ -179,7 +179,7 @@ const Link = ({
 				>
 					<LinkControl
 						hasTextControl
-						className="mconnect-block-components-link__link-control"
+						className="tenup-block-components-link__link-control"
 						value={link}
 						showInitialSuggestions
 						noDirectEntry={!!type}

--- a/components/Link/index.js
+++ b/components/Link/index.js
@@ -11,11 +11,7 @@ import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { Popover, Icon, Tooltip } from '@wordpress/components';
-import {
-	__experimentalLinkControl as LinkControl,
-	RichText,
-	useBlockEditContext,
-} from '@wordpress/block-editor';
+import { __experimentalLinkControl as LinkControl, RichText } from '@wordpress/block-editor';
 
 /**
  * Internal Dependencies
@@ -118,7 +114,6 @@ const Link = ({
 	const ref = useRef();
 	const [isLinkOpen, setIsLinkOpen] = useState(false);
 	const [isValid, setIsValid] = useState(false);
-	const { isSelected } = useBlockEditContext();
 	const openPopover = () => setIsLinkOpen(true);
 	const closePopover = () => setIsLinkOpen(false);
 
@@ -129,14 +124,6 @@ const Link = ({
 		opensInNewTab,
 		title: value, // don't allow HTML to display inside the <LinkControl>
 	};
-
-	/**
-	 * The hook shouldn't be necessary but due to a focus loss happening
-	 * when selecting a suggestion in the link popover, we force close on block un-selection.
-	 */
-	useEffect(() => {
-		if (!isSelected) closePopover();
-	}, [isSelected]);
 
 	/**
 	 * Check if the URL and Value are set. If yes, then the component is valid.

--- a/components/Link/index.js
+++ b/components/Link/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
@@ -152,7 +152,7 @@ const Link = ({
 			<LinkOutput
 				tagName="a"
 				identifier="label"
-				className={classNames('tenup-block-components-link__label', className)}
+				className={classnames('tenup-block-components-link__label', className)}
 				value={value}
 				onChange={onTextChange}
 				aria-label={__('Link text', '10up-block-components')}

--- a/components/Link/index.js
+++ b/components/Link/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
@@ -16,7 +17,9 @@ import {
 	useBlockEditContext,
 } from '@wordpress/block-editor';
 
-import classNames from 'classnames';
+/**
+ * Internal Dependencies
+ */
 import { useOnClickOutside } from '../../hooks/use-on-click-outside';
 
 /**

--- a/example/src/blocks/link-example/block.json
+++ b/example/src/blocks/link-example/block.json
@@ -1,0 +1,23 @@
+{
+    "name": "example/link-example",
+    "title": "Link Example",
+    "description": "Example Block to show the Link Component in usage",
+    "icon": "smiley",
+    "category": "common",
+    "example": {},
+    "supports": {
+        "html": false
+    },
+    "attributes": {
+        "url": {
+            "type": "string"
+        },
+        "text": {
+            "type": "string"
+        },
+        "opensInNewTab": {
+            "type": "boolean",
+            "default": false
+        }
+    }
+}

--- a/example/src/blocks/link-example/edit.js
+++ b/example/src/blocks/link-example/edit.js
@@ -1,0 +1,39 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import { Link } from '@10up/block-components';
+
+export function BlockEdit(props) {
+    const {
+        attributes,
+        setAttributes
+    } = props;
+
+    const { text, url, opensInNewTab } = attributes;
+
+    const blockProps = useBlockProps();
+
+    const handleTextChange = value => setAttributes({text: value});
+    const handleLinkChange = value => setAttributes({
+        url: value?.url,
+        opensInNewTab: value?.opensInNewTab,
+        text: value?.title ?? text
+    });
+
+    return (
+        <div {...blockProps}>
+            <h2>Hello World!</h2>
+            <div>
+                <Link 
+                    value={text}
+                    url={url}
+                    opensInNewTab={opensInNewTab}
+                    onTextChange={handleTextChange}
+                    onLinkChange={handleLinkChange}
+                    className='example-classname'
+                    placeholder='Enter Link Text here...'
+                />
+            </div>
+        </div>
+    )
+}

--- a/example/src/blocks/link-example/edit.js
+++ b/example/src/blocks/link-example/edit.js
@@ -23,17 +23,15 @@ export function BlockEdit(props) {
     return (
         <div {...blockProps}>
             <h2>Hello World!</h2>
-            <div>
-                <Link 
-                    value={text}
-                    url={url}
-                    opensInNewTab={opensInNewTab}
-                    onTextChange={handleTextChange}
-                    onLinkChange={handleLinkChange}
-                    className='example-classname'
-                    placeholder='Enter Link Text here...'
-                />
-            </div>
+            <Link 
+                value={text}
+                url={url}
+                opensInNewTab={opensInNewTab}
+                onTextChange={handleTextChange}
+                onLinkChange={handleLinkChange}
+                className='example-classname'
+                placeholder='Enter Link Text here...'
+            />
         </div>
     )
 }

--- a/example/src/blocks/link-example/index.js
+++ b/example/src/blocks/link-example/index.js
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import { BlockEdit } from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata, {
+    edit: BlockEdit,
+    save: () => null
+} );

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,3 +1,4 @@
 import './blocks/hello-world';
 import './extentions/background-pattern';
 import './blocks/icon-picker-example';
+import './blocks/link-example';

--- a/hooks/use-on-click-outside.js
+++ b/hooks/use-on-click-outside.js
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * useOnClickOutside
+ *
+ * @param {Function} onClickOutside callback that will get invoked when the user clicks outside of the target
+ * @returns {React.RefObject<HTMLElement>}
+ */
+export function useOnClickOutside(onClickOutside) {
+	const ref = useRef();
+	useEffect(
+		() => {
+			const listener = (event) => {
+				// Do nothing if clicking ref's element or descendent elements
+				if (!ref.current || ref.current.contains(event.target)) {
+					return;
+				}
+				onClickOutside(event);
+			};
+			document.addEventListener('mousedown', listener);
+			document.addEventListener('touchstart', listener);
+			return () => {
+				document.removeEventListener('mousedown', listener);
+				document.removeEventListener('touchstart', listener);
+			};
+		},
+		// Add ref and handler to effect dependencies
+		// It's worth noting that because passed in handler is a new function on every
+		// render that will cause this effect callback/cleanup to run every render.
+		// It's not a big deal but to optimize you can wrap handler in useCallback before
+		// passing it into this hook.
+		[ref, onClickOutside],
+	);
+
+	return ref;
+}

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ export { InnerBlockSlider } from './components/InnerBlockSlider';
 export { Link } from './components/Link';
 export { IsAdmin } from './components/is-admin';
 export { useHasSelectedInnerBlock } from './hooks/use-has-selected-inner-block';
+export { useOnClickOutside } from './hooks/use-on-click-outside';
 export { useRequestData } from './hooks/use-request-data';
 export { default as CustomBlockAppender } from './components/CustomBlockAppender';
 export { registerBlockExtention } from './api/registerBlockExtention';


### PR DESCRIPTION
This PR enhances the work in #66 by adding a `useOnClickOutside` hook and cleaning up how the component manages it's popover state