### PR TITLE
feat/27: Added support for mode = user on the ContentPicker component

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ function MyComponent( props ) {
 | ---------------- | ---------- | --------------------- | ---------------------------------------------------------------------- |
 | `onPickChange`   | `function` | `undefined`            | Callback function the list of picked content gets changed |
 | `label`          | `string`   | `''`                   | Renders a label for the Search Field.                                  |
-| `mode`           | `string`   | `'post'`               | Either `post` or `term`                                 |
+| `mode`           | `string`   | `'post'`               | One of: `post`, `search`, `term`                                 |
 | `placeholder`    | `string`   | `''`                   | Renders placeholder text inside the Search Field.                      |
 | `contentTypes`      | `array`    | `[ 'post', 'page' ]` | Names of the post types or taxonomies that should get searched                       |
 | `maxContentItems`          | `number`   | `1`                   | Max number of items a user can select.
@@ -89,7 +89,7 @@ function MyComponent( props ) {
 | ---------------- | ---------- | --------------------- | ---------------------------------------------------------------------- |
 | `onSelectItem`   | `function` | `undefined`            | Function called when a searched item is clicke |
 | `label`          | `string`   | `''`                   | Renders a label for the Search Field.                                  |
-| `mode`           | `string`   | `'post'`               | Either `post` or `term`                                 |
+| `mode`           | `string`   | `'post'`               | One of: `post`, `search`, `term`                                 |
 | `placeholder`    | `string`   | `''`                   | Renders placeholder text inside the Search Field.                      |
 | `contentTypes`      | `array`    | `[ 'post', 'page' ]` | Names of the post types or taxonomies that should get searched                       |
 | `excludeItems`      | `array`    | `[ { id: 1, type: 'post' ]` | Items to exclude from search |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ function MyComponent( props ) {
 | ---------------- | ---------- | --------------------- | ---------------------------------------------------------------------- |
 | `onPickChange`   | `function` | `undefined`            | Callback function the list of picked content gets changed |
 | `label`          | `string`   | `''`                   | Renders a label for the Search Field.                                  |
-| `mode`           | `string`   | `'post'`               | One of: `post`, `search`, `term`                                 |
+| `mode`           | `string`   | `'post'`               | One of: `post`, `user`, `term`                                 |
 | `placeholder`    | `string`   | `''`                   | Renders placeholder text inside the Search Field.                      |
 | `contentTypes`      | `array`    | `[ 'post', 'page' ]` | Names of the post types or taxonomies that should get searched                       |
 | `maxContentItems`          | `number`   | `1`                   | Max number of items a user can select.
@@ -89,7 +89,7 @@ function MyComponent( props ) {
 | ---------------- | ---------- | --------------------- | ---------------------------------------------------------------------- |
 | `onSelectItem`   | `function` | `undefined`            | Function called when a searched item is clicke |
 | `label`          | `string`   | `''`                   | Renders a label for the Search Field.                                  |
-| `mode`           | `string`   | `'post'`               | One of: `post`, `search`, `term`                                 |
+| `mode`           | `string`   | `'post'`               | One of: `post`, `user`, `term`                                 |
 | `placeholder`    | `string`   | `''`                   | Renders placeholder text inside the Search Field.                      |
 | `contentTypes`      | `array`    | `[ 'post', 'page' ]` | Names of the post types or taxonomies that should get searched                       |
 | `excludeItems`      | `array`    | `[ { id: 1, type: 'post' ]` | Items to exclude from search |

--- a/components/ContentPicker/PickedItem.js
+++ b/components/ContentPicker/PickedItem.js
@@ -46,7 +46,19 @@ const Wrapper = styled('div')`
 `;
 
 const PickedItem = ({ item, isOrderable, handleItemDelete, mode }) => {
-	const type = mode === 'post' ? 'postType' : 'taxonomy';
+	let type;
+
+	switch (mode) {
+		case 'post':
+			type = 'postType';
+			break;
+		case 'user':
+			type = 'root';
+			break;
+		default:
+			type = 'taxonomy';
+			break;
+	}
 
 	// This will return undefined while the item data is being fetched. If the item comes back
 	// empty, it will return null, which is handled in the effect below.


### PR DESCRIPTION
Closes #27 

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Setting the `mode` prop to `user` on the `ContentPicker` component now allows you to search for users.

### Screenshot

#### Search in progress:

<img width="643" alt="Screen Shot 2022-01-14 at 1 13 19 PM" src="https://user-images.githubusercontent.com/17757960/149534240-43c105ab-1af1-4f01-afda-ef274536ce00.png">

#### After selecting a search result:

<img width="646" alt="Screen Shot 2022-01-14 at 1 13 33 PM" src="https://user-images.githubusercontent.com/17757960/149534250-64c0ccc8-5909-4f92-b01a-26a75963cc1b.png">


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->


### Changelog Entry

> feature: extend ContentPicker component to search users by setting mode prop to user
