### PR TITLE
fix/25: Always show ContentPicker label

### DIFF
--- a/components/ContentPicker/index.js
+++ b/components/ContentPicker/index.js
@@ -117,7 +117,7 @@ const ContentPicker = ({
 
 	return (
 		<div className={`${NAMESPACE}`}>
-			{(!content.length || (content.length && content.length < maxContentItems)) && (
+			{(!content.length || (content.length && content.length < maxContentItems)) ? (
 				<ContentSearch
 					placeholder={placeholder}
 					label={label}
@@ -127,6 +127,16 @@ const ContentPicker = ({
 					mode={mode}
 					perPage={perPage}
 				/>
+			) : (
+				label && (
+					<div
+						style={{
+							'margin-bottom': '8px',
+						}}
+					>
+						{label}
+					</div>
+				)
 			)}
 			{Boolean(content?.length) > 0 && (
 				<StyleWrapper>


### PR DESCRIPTION
Closes #25 

### Description of the Change

This fix makes the Content Picker label always show when `maxContentItems` is reached.

### Screencast


https://user-images.githubusercontent.com/17757960/149567703-2638edf1-843e-48d1-8887-d3c35317ffd4.mov



### Changelog Entry
fix: always show ContentPicker label
