### PR TITLE
Fixing incorrect link to ColorSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ A collection of components built to be used in the block editor. These component
 ## Components
 
 - [ClipboardButton](./components/clipboard-button/)
-- [ColorSettings](./components//clipboard-button/)
-- [ContentPicker](./components//content-picker/)
+- [ColorSettings](./components/color-settings/)
+- [ContentPicker](./components/content-picker/)
 - [ContentSearch](./components/content-search/)
 - [CustomBlockAppender](./components/custom-block-appender/)
 - [IconPicker](./components/icon-picker/)
 - [InnerBlockSlider](./components/inner-block-slider/)
-- [IsAdmin](./components//is-admin/)
+- [IsAdmin](./components/is-admin/)
 - [Optional](./components/optional/)
 
 ## Hooks


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fixing incorrect link to ColorSettings + removing some double slashes in readme

### Alternate Designs

--

### Possible Drawbacks

None

### Verification Process

--

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - url to ColorSettings in readme

### Credits

--
