### PR TITLE
add prepublish only script to ensure that we always publish build changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "10up-toolkit build",
     "start": "10up-toolkit start",
     "test:e2e": "cypress open",
-	"prepublishOnly": "npm run lint && npm run build"
+    "prepublishOnly": "npm run lint && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "10up-toolkit test-unit-jest",
     "build": "10up-toolkit build",
     "start": "10up-toolkit start",
-    "test:e2e": "cypress open"
+    "test:e2e": "cypress open",
+	"prepublishOnly": "npm run lint && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is to ensure that we always deploy the build files. 