### PR TITLE
Return removed feature

### DIFF
--- a/components/content-picker/PickedItem.js
+++ b/components/content-picker/PickedItem.js
@@ -123,13 +123,16 @@ const PickedItem = ({ item, isOrderable, handleItemDelete, mode, id }) => {
 		paddingLeft: isOrderable ? '3px' : '8px',
 	};
 
+	const normalizedItemType = item?.type ? item.type : 'post';
+	const className = `block-editor-link-control__search-item is-entity is-type-${normalizedItemType}`;
+
 	if (!preparedItem) {
 		return null;
 	}
 
 	return (
 		<li
-			className="block-editor-link-control__search-item is-entity"
+			className={className}
 			ref={setNodeRef}
 			style={style}
 		>

--- a/components/content-picker/index.js
+++ b/components/content-picker/index.js
@@ -142,7 +142,7 @@ const ContentPicker = ({
 				)
 			)}
 
-			{Boolean(content?.length) > 0 && (
+			{Boolean(content?.length) && (
 				<StyleWrapper>
 					<span
 						style={{

--- a/components/content-picker/index.js
+++ b/components/content-picker/index.js
@@ -154,13 +154,15 @@ const ContentPicker = ({
 						{content.length > 1 ? multiPickedLabel : singlePickedLabel}
 					</span>
 
-					<SortableList
-						posts={content}
-						handleItemDelete={onDeleteItem}
-						isOrderable={isOrderable}
-						mode={mode}
-						setPosts={onPickChange}
-					/>
+					<ul className="block-editor-link-control__search-items">
+						<SortableList
+							posts={content}
+							handleItemDelete={onDeleteItem}
+							isOrderable={isOrderable}
+							mode={mode}
+							setPosts={onPickChange}
+						/>
+					</ul>
 				</StyleWrapper>
 			)}
 		</ContentPickerWrapper>

--- a/components/content-picker/index.js
+++ b/components/content-picker/index.js
@@ -118,7 +118,7 @@ const ContentPicker = ({
 	}, [content, currentPostId, excludeCurrentPost, uniqueContentItems]);
 
 	return (
-		<ContentPickerWrapper className={`${NAMESPACE}`}>
+		<ContentPickerWrapper className={NAMESPACE}>
 			{!content.length || (content.length && content.length < maxContentItems) ? (
 				<ContentSearch
 					placeholder={placeholder}

--- a/components/content-search/readme.md
+++ b/components/content-search/readme.md
@@ -22,14 +22,14 @@ function MyComponent( props ) {
 
 ## Props
 
-| Name           | Type       | Default                     | Description                                                                                                                    |
-|----------------|------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `onSelectItem` | `function` | `undefined`                 | Function called when a searched item is clicked                                                                                |
-| `queryFilter`  | `function` | `(query) => query`          | Function called to allow you to customize the query before is made. It's advisable to use `useCallback` to save this parameter |
-| `label`        | `string`   | `''`                        | Renders a label for the Search Field.                                                                                          |
-| `mode`         | `string`   | `'post'`                    | One of: `post`, `user`, `term`                                                                                                 |
-| `placeholder`  | `string`   | `''`                        | Renders placeholder text inside the Search Field.                                                                              |
-| `contentTypes` | `array`    | `[ 'post', 'page' ]`        | Names of the post types or taxonomies that should get searched                                                                 |
-| `excludeItems` | `array`    | `[ { id: 1, type: 'post' ]` | Items to exclude from search                                                                                                   |
-| `perPage`      | `number`   | `50`                        | Number of items to show during search                                                                                          |
+| Name           | Type       | Default                              | Description                                                                                                                    |
+|----------------|------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `onSelectItem` | `function` | `undefined`                          | Function called when a searched item is clicked                                                                                |
+| `queryFilter`  | `function` | `(query, parametersObject) => query` | Function called to allow you to customize the query before is made. It's advisable to use `useCallback` to save this parameter |
+| `label`        | `string`   | `''`                                 | Renders a label for the Search Field.                                                                                          |
+| `mode`         | `string`   | `'post'`                             | One of: `post`, `user`, `term`                                                                                                 |
+| `placeholder`  | `string`   | `''`                                 | Renders placeholder text inside the Search Field.                                                                              |
+| `contentTypes` | `array`    | `[ 'post', 'page' ]`                 | Names of the post types or taxonomies that should get searched                                                                 |
+| `excludeItems` | `array`    | `[ { id: 1, type: 'post' ]`          | Items to exclude from search                                                                                                   |
+| `perPage`      | `number`   | `50`                                 | Number of items to show during search                                                                                          |
 


### PR DESCRIPTION
### Description of the Change

Filtering items (even selected ones) wasn't working anymore. This got deleted at some point during the refactor for state management within `ContentSearch` which seemed like an oversight since the documentation was unaltered.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.

### Changelog Entry

> Fixed: Ensure `excludeItems` is honored within `ContentSearch` again.
> Updated: `queryFilter` now also receives all the parameters that are used to perform a query.