### PR TITLE
add support for passing multiple blocks to the registerBlockExtension API

### DIFF
--- a/api/register-block-extension/index.js
+++ b/api/register-block-extension/index.js
@@ -39,6 +39,8 @@ function registerBlockExtension(
 		return blockType === blockName;
 	};
 
+	const blockNamespace = isMultiBlock ? blockName.join('-') : blockName;
+
 	/**
 	 * addAttributesToBlock
 	 *
@@ -64,7 +66,7 @@ function registerBlockExtension(
 
 	addFilter(
 		'blocks.registerBlockType',
-		`namespace/${blockName}/${extensionName}/addAttributesToBlock`,
+		`namespace/${blockNamespace}/${extensionName}/addAttributesToBlock`,
 		addAttributesToBlock,
 	);
 
@@ -91,7 +93,7 @@ function registerBlockExtension(
 
 	addFilter(
 		'editor.BlockEdit',
-		`namespace/${blockName}/${extensionName}/addSettingsToBlock`,
+		`namespace/${blockNamespace}/${extensionName}/addSettingsToBlock`,
 		addSettingsToBlock,
 	);
 
@@ -124,7 +126,7 @@ function registerBlockExtension(
 
 	addFilter(
 		'editor.BlockListBlock',
-		`namespace/${blockName}/${extensionName}/addClassNameInEditor`,
+		`namespace/${blockNamespace}/${extensionName}/addClassNameInEditor`,
 		addClassNameInEditor,
 	);
 
@@ -153,7 +155,7 @@ function registerBlockExtension(
 
 	addFilter(
 		'blocks.getSaveContent.extraProps',
-		`namespace/${blockName}/${extensionName}/saveSpacingAttributes`,
+		`namespace/${blockNamespace}/${extensionName}/saveSpacingAttributes`,
 		saveSpacingAttributes,
 	);
 }

--- a/api/register-block-extension/index.js
+++ b/api/register-block-extension/index.js
@@ -17,13 +17,28 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * @property {Function} Edit               block edit extension function. Will only get rendered when the block is selected
  * @property {string}   extensionName      unique identifier used for the name of the addFilter calls
  *
- * @param {string}             blockName name of the block
+ * @param {string|string[]}    blockName name of the block or array of block names
  * @param {BlockOptionOptions} options   configuration options
  */
 function registerBlockExtension(
 	blockName,
 	{ attributes, classNameGenerator, Edit, extensionName },
 ) {
+	const isMultiBlock = Array.isArray(blockName);
+
+	/**
+	 * shouldApplyBlockExtension
+	 *
+	 * @param {string} blockType name of the block
+	 * @returns {boolean} true if the block is the one we want to add the extension to
+	 */
+	const shouldApplyBlockExtension = (blockType) => {
+		if (isMultiBlock) {
+			return blockName.includes(blockType);
+		}
+		return blockType === blockName;
+	};
+
 	/**
 	 * addAttributesToBlock
 	 *
@@ -33,7 +48,7 @@ function registerBlockExtension(
 	 */
 	const addAttributesToBlock = (settings, name) => {
 		// return early from the block modification
-		if (name !== blockName) {
+		if (!shouldApplyBlockExtension(name)) {
 			return settings;
 		}
 
@@ -61,7 +76,7 @@ function registerBlockExtension(
 			const { name, isSelected } = props;
 
 			// return early from the block modification
-			if (name !== blockName) {
+			if (!shouldApplyBlockExtension(name)) {
 				return <BlockEdit {...props} />;
 			}
 
@@ -88,7 +103,7 @@ function registerBlockExtension(
 			const { name, attributes } = props;
 
 			// return early from the block modification
-			if (name !== blockName) {
+			if (!shouldApplyBlockExtension(name)) {
 				return <BlockList {...props} />;
 			}
 
@@ -123,7 +138,7 @@ function registerBlockExtension(
 	 */
 	const saveSpacingAttributes = (props, block, attributes) => {
 		// return early from the block modification
-		if (block.name !== blockName) {
+		if (!shouldApplyBlockExtension(block.name)) {
 			return props;
 		}
 

--- a/api/register-block-extension/readme.md
+++ b/api/register-block-extension/readme.md
@@ -49,7 +49,7 @@ function BlockEdit(props) {...}
 function generateClassNames(attributes) {...}
 
 registerBlockExtension(
- 'core/group',
+ 'core/group', // also supports adding multiple blocks as an array
  {
   extensionName: 'background-patterns',
   attributes: additionalAttributes,
@@ -63,7 +63,7 @@ registerBlockExtension(
 
 | Name                       | Type       | Description                                       |
 |----------------------------|------------|---------------------------------------------------|
-| blockName                  | `string`   | Name of the block the options should get added to |
+| blockName                  | `string|string[]`   | Name of the block or array with multiple block names the options should get added to |
 | options.extensionName      | `string`   | Unique Identifier of the option added    |
 | options.attributes         | `object`   | Block Attributes that should get added to the block |
 | options.classNameGenerator | `function` | Function that gets passed the attributes of the block to generate a class name string |


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Before this, it was only possible to add a block extension to one block at a time. This is very limiting since many of the extensions we see on a day-to-day basis are getting applied to multiple blocks simultaneously.

With this change, the first parameter of the `registerBlockExtension` accepts either a string or an array of strings.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Update example registerBlockExtension to include more than one block.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

- Added ability to provide multiple blocks to registerBlockExtension API


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
