### PR TITLE
add `useBlockParentAttributes` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A collection of components built to be used in the block editor. These component
 - [useIcons](./hooks/use-icons/)
 - [useMedia](./hooks/use-media/)
 - [useRequestData](./hooks/use-request-data/)
+- [useBlockParentAttributes](./hooks/use-block-parent-attributes/)
 
 ## Stores
 

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -3,3 +3,4 @@ export { useRequestData } from './use-request-data';
 export { useIcons, useIcon } from './use-icons';
 export { useFilteredList } from './use-filtered-list';
 export { useMedia } from './use-media';
+export { useBlockParentAttributes } from './use-block-parent-attributes';

--- a/hooks/use-block-parent-attributes/index.js
+++ b/hooks/use-block-parent-attributes/index.js
@@ -1,0 +1,32 @@
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore, useBlockEditContext } from '@wordpress/block-editor';
+
+/**
+ * useBlockParentAttributes
+ *
+ * allows you to easily interface with the attributes of the direct
+ * parent of the current block
+ *
+ * @typedef {object} BlockAttributes - Attributes of the blocks parent
+ * @typedef {Function} BlockAttributeSetter - Setter function for the blocks parent attributes
+ * @typedef {[BlockAttributes, BlockAttributeSetter]} BlockParentAttributesTuple
+ *
+ * @returns {BlockParentAttributesTuple} - the attributes of the direct parent of the current block and a function to update the attributes
+ */
+export function useBlockParentAttributes() {
+	const { clientId } = useBlockEditContext();
+	const parentBlocks = useSelect((select) => select(blockEditorStore).getBlockParents(clientId));
+	const parentBlockClientId = parentBlocks[parentBlocks.length - 1];
+
+	const parentBlock = useSelect((select) =>
+		select(blockEditorStore).getBlock(parentBlockClientId),
+	);
+
+	const { updateBlockAttributes } = useDispatch(blockEditorStore);
+
+	const setParentAttributes = (attributes) => {
+		updateBlockAttributes(parentBlockClientId, attributes);
+	};
+
+	return [parentBlock?.attributes ?? {}, setParentAttributes];
+}

--- a/hooks/use-block-parent-attributes/readme.md
+++ b/hooks/use-block-parent-attributes/readme.md
@@ -1,0 +1,21 @@
+# `useBlockParentAttributes`
+
+The `useBlockParentAttributes` hook is a simple utility that makes it easy interface with the attributes of the direct parent block.
+
+## Usage
+
+```js
+import { useBlockParentAttributes } from '@10up/block-components';
+
+function BlockEdit(props) {
+    const [parentAttributes, setParentAttributes] = useBlockParentAttributes();
+
+    return (
+        <RichText
+            tagName="h2"
+            value={ parentAttributes.title }
+            onChange={ value => setParentAttributes({ title: value }) }
+         />
+    );
+}
+```


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Sometimes there are instances where one block needs to update the attributes of another block. This especially happens with direct parent child block relationships like for example the core column block needing to update the vertical alignment value of the core columns block. 

This has always been possible with the usage of the Data API. But it is a lot of code that could be abstracted away. This is what the `useBlockParentAttributes` hook does. 

```js
import { useBlockParentAttributes } from '@10up/block-components';

function BlockEdit(props) {
    const [parentAttributes, setParentAttributes] = useBlockParentAttributes();

    return (
        <RichText
            tagName="h2"
            value={ parentAttributes.title }
            onChange={ value => setParentAttributes({ title: value }) }
         />
    );
}
```

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - `useBlockParentAttributes` hook to easily interface with the attributes of the direct parent block


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
