### PR TITLE
add `RichTextCharacterLimit` component

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -12,3 +12,4 @@ export { Repeater } from './repeater';
 export { Link } from './link';
 export { MediaToolbar } from './media-toolbar';
 export { Image } from './image';
+export { RichTextCharacterLimit } from './rich-text-character-limit';

--- a/components/rich-text-character-limit/index.js
+++ b/components/rich-text-character-limit/index.js
@@ -60,7 +60,7 @@ const RichTextCharacterLimit = (props) => {
 		const isOverLimit = getCharacterCount(str) > limit;
 
 		if (isOverLimit && enforce) {
-			// Hack which fixes an issue with `<RichText>` not updating.
+			// Workaround which fixes an issue with `<RichText>` not updating.
 			setRichTextValue('');
 			return remove(richTextContent, limit, getCharacterCount(str));
 		}

--- a/components/rich-text-character-limit/index.js
+++ b/components/rich-text-character-limit/index.js
@@ -50,7 +50,7 @@ const RichTextCharacterLimit = (props) => {
 	/**
 	 * Sanitize
 	 * 
-	 * @description
+	 * @description remove characters if `enforce` is set to true.
 	 * 
 	 * @param {string} str
 	 * @returns {string} str
@@ -71,7 +71,7 @@ const RichTextCharacterLimit = (props) => {
 	/**
 	 * Rich Text On Change
 	 * 
-	 * @description
+	 * @description set rich text value and run `onChange` from initial props.
 	 * 
 	 * @param {string} str 
 	 */
@@ -84,7 +84,7 @@ const RichTextCharacterLimit = (props) => {
 	/**
 	 * Counter
 	 * 
-	 * @description
+	 * @description display character count and limit.
 	 * 
 	 * @returns <Counter />
 	 */

--- a/components/rich-text-character-limit/index.js
+++ b/components/rich-text-character-limit/index.js
@@ -1,0 +1,127 @@
+import cx from 'classnames';
+import { useState, useEffect } from '@wordpress/element';
+import { RichText } from '@wordpress/block-editor';
+import { create, remove, getTextContent, toHTMLString } from '@wordpress/rich-text';
+import PropTypes from 'prop-types';
+
+/**
+ * Get Character Count
+ * 
+ * @description get character count from `RichText` string.
+ * 
+ * @param {string} string
+ * @returns {integer} text content length
+ */
+const getCharacterCount = (str) => {
+	const richTextContent = create({ html: str });
+	const textContent = getTextContent(richTextContent);
+	return textContent.length;
+}
+
+/**
+ * Rich Text Character Limit
+ * 
+ * @description extend `RichText` with the ability to add a character limit.
+ * 
+ * @param {object} props 
+ * @returns <RichTextCharacterLimit />
+ */
+const RichTextCharacterLimit = (props) => {
+	const {
+		limit = 100,
+		enforce = true,
+		value,
+		onChange
+	} = props;
+
+	/**
+	 * State
+	 */
+	const [count, setCount] = useState(0);
+	const [richTextValue, setRichTextValue] = useState(value);
+
+	/**
+	 * Effects
+	 */
+	useEffect(() => {
+		setCount(getCharacterCount(richTextValue));
+	}, [richTextValue]);
+
+	/**
+	 * Sanitize
+	 * 
+	 * @description
+	 * 
+	 * @param {string} str
+	 * @returns {string} str
+	 */
+	const sanitize = (str = value) => {
+		const richTextContent = create({ html: str });
+		const isOverLimit = getCharacterCount(str) > limit;
+
+		if (isOverLimit && enforce) {
+			// Hack which fixes an issue with `<RichText>` not updating.
+			setRichTextValue('');
+			return remove(richTextContent, limit, getCharacterCount(str));
+		}
+
+		return richTextContent;
+	}
+
+	/**
+	 * Rich Text On Change
+	 * 
+	 * @description
+	 * 
+	 * @param {string} str 
+	 */
+	const richTextOnChange = (str = value) => {
+		const sanitized = toHTMLString({ value: sanitize(str) });
+		setRichTextValue(sanitized);
+		onChange(sanitized);
+	}
+
+	/**
+	 * Counter
+	 * 
+	 * @description
+	 * 
+	 * @returns <Counter />
+	 */
+	const Counter = () => (
+		<div
+			className={cx('tenup--block-components__character-count', {
+				'is-over-limit': count > limit,
+			})}
+		>
+			<span className="tenup--block-components__character-count__count">{count}</span> /{' '}
+			<span className="tenup--block-components__character-count__limit">{limit}</span>
+		</div>
+	);
+
+	/**
+	 * Render
+	 */
+	return (
+		<>
+			<RichText { ...{
+				...props,
+				value: richTextValue,
+				onChange: (str) => richTextOnChange(str),
+			} } />
+			<Counter />
+		</>
+	);
+}
+
+export { RichTextCharacterLimit };
+
+RichTextCharacterLimit.defaultProps = {
+	limit: 100,
+	enforce: true,
+};
+
+RichTextCharacterLimit.propTypes = {
+	limit: PropTypes.number,
+	enforce: PropTypes.boolean,
+};

--- a/components/rich-text-character-limit/readme.md
+++ b/components/rich-text-character-limit/readme.md
@@ -17,8 +17,9 @@ function BlockEdit(props) {
         <RichTextCharacterLimit
             limit={30}
             enforce={true}
-            tagName='h2'
+            tagName="h2"
             value={title}
+			placeholder={ __( 'Enter some text', NAMESPACE ) }
             onChange={(title) => setAttributes({title})}
             allowedFormats={[
                 'core/bold',

--- a/components/rich-text-character-limit/readme.md
+++ b/components/rich-text-character-limit/readme.md
@@ -1,0 +1,37 @@
+# Rich Text Character Limit
+
+The Rich Text Character Limit component enables the ability to add content character limits to rich text.
+
+`RichTextCharacterLimit` extends `RichText` and can accept all the same props as `RichText` does. Please see 
+
+## Usage
+
+```js
+import { RichTextCharacterLimit } from '@10up/block-components';
+
+function BlockEdit(props) {
+    const { attributes, setAttributes } = props;
+    const { title } = attributes;
+
+    return (
+        <RichTextCharacterLimit
+            limit={30}
+            enforce={true}
+            tagName='h2'
+            value={title}
+            onChange={(title) => setAttributes({title})}
+            allowedFormats={[
+                'core/bold',
+                'core/link'
+            ]}
+        />
+    )
+}
+```
+
+## Props
+
+| Name       | Type              | Default  |  Description                                                   |
+| ---------- | ----------------- | -------- | -------------------------------------------------------------- |
+| `limit` | `number` | `100` | Maximum amount of characters |
+| `enforce` | `boolean` | `true` | Enforce the character limit by restricting content |

--- a/example/src/blocks/rich-text-character-limit/index.js
+++ b/example/src/blocks/rich-text-character-limit/index.js
@@ -1,0 +1,50 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+import { RichTextCharacterLimit } from '@10up/block-components';
+
+const NAMESPACE = 'example';
+
+registerBlockType( `${ NAMESPACE }/rich-text-character-limit`, {
+	apiVersion: 2,
+	title: __( 'Rich Text Character Limit', NAMESPACE ),
+	description: __( 'Example Block to show the Rich Text Character Limit in usage', NAMESPACE ),
+	icon: 'smiley',
+	category: 'common',
+	example: {},
+	supports: {
+		html: false
+	},
+	attributes: {
+		title: {
+			type: 'string',
+			default: ''
+		}
+	},
+	edit: (props) => {
+		const {
+			attributes: { title },
+			setAttributes
+		} = props;
+
+		const blockProps = useBlockProps();
+
+		return (
+			<div {...blockProps}>
+				<RichTextCharacterLimit
+					limit={30}
+					enforce={true}
+					tagName="h2"
+					value={title}
+					placeholder={ __( 'Enter some text', NAMESPACE ) }
+					onChange={(title) => setAttributes({title})}
+					allowedFormats={[
+						'core/bold',
+						'core/link'
+					]}
+				/>
+			</div>
+		)
+	},
+	save: () => null
+} );


### PR DESCRIPTION
### Description of the Change
Extend `RichText` with `RichTextCharacterLimit` in order to enable character limits on rich text content. 

### How to test the Change

```js
import { RichTextCharacterLimit } from '@10up/block-components';

function BlockEdit(props) {
    const { attributes, setAttributes } = props;
    const { title } = attributes;

    return (
        <RichTextCharacterLimit
            limit={30}
            enforce={true}
            tagName='h2'
            value={title}
            onChange={(title) => setAttributes({title})}
            allowedFormats={[
                'core/bold',
                'core/link'
            ]}
        />
    )
}
```

Attribute `title` should never exceed the character limit unless `enforce` is set to `false`. If `enforce` is set to `false`, the author will be able to exceed the character limit. Both instances will show a character counter below the `RichText` component.

### Credits
Props @fabiankaegy 

### Related

https://github.com/10up/block-components/pull/131 
@fabiankaegy should we favour a component versus a hook? The implementation and DX feels cleaner.

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.

_Please let me know if I can add tests._