### PR TITLE
fix not entire link component is clickable in empty placeholder state

### DIFF
--- a/components/link/index.js
+++ b/components/link/index.js
@@ -57,7 +57,7 @@ const StylesRichTextLink = styled(RichText)`
 
 	color: var(--wp--style--color--link);
 	position: relative;
-	display: inline-flex;
+	display: block;
 	align-items: center;
 	gap: 0.5em;
 	text-decoration: underline;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #140 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Target area size of the link component contenteditable area when the placeholder is shown 

