### PR TITLE
fix highlighting issue caused by inline html inside page title

### DIFF
--- a/components/content-search/SearchItem.js
+++ b/components/content-search/SearchItem.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Button, TextHighlight, Tooltip } from '@wordpress/components';
+import { getTextContent, create } from '@wordpress/rich-text';
 
 const ButtonStyled = styled(Button)`
 	&:hover {
@@ -35,6 +36,10 @@ const ButtonStyled = styled(Button)`
 const SearchItem = ({ suggestion, onClick, searchTerm, isSelected, id, contentTypes }) => {
 	const showType = suggestion.type && contentTypes.length > 1;
 
+	const richTextContent = create({ html: suggestion.title });
+	const textContent = getTextContent(richTextContent);
+	const titleContent = decodeEntities(textContent);
+
 	return (
 		<Tooltip text={decodeEntities(suggestion.title)}>
 			<ButtonStyled
@@ -55,10 +60,7 @@ const SearchItem = ({ suggestion, onClick, searchTerm, isSelected, id, contentTy
 							paddingRight: !showType ? 0 : null,
 						}}
 					>
-						<TextHighlight
-							text={decodeEntities(suggestion.title)}
-							highlight={searchTerm}
-						/>
+						<TextHighlight text={titleContent} highlight={searchTerm} />
 					</span>
 					<span
 						aria-hidden


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

On a recent project, I noticed, that the content search component threw an error because a title of a post contained raw HTML markup (inline rich text formats). Whilst this will not always be the case this PR adds a safeguard around the title to ensure only the actual text content gets used in the highlight component which prevents it from crashing.


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Create a new post with some markup in the page title
- use the ContentSearch component and search for that title
- you will see that the component crashes before this update.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Issue where plain markup in page titles caused the content search component to crash


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
