### PR TITLE
add new order option to registerBlockExtension API

### DIFF
--- a/api/register-block-extension/index.js
+++ b/api/register-block-extension/index.js
@@ -16,13 +16,14 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * @property {Function} classNameGenerator function that gets passed the attributes and should return a string for the classname
  * @property {Function} Edit               block edit extension function. Will only get rendered when the block is selected
  * @property {string}   extensionName      unique identifier used for the name of the addFilter calls
+ * @property {string}   order              the order where the extension should be rendered. Can be 'before' or 'after'. Defaults to 'after'
  *
  * @param {string|string[]}    blockName name of the block or array of block names
  * @param {BlockOptionOptions} options   configuration options
  */
 function registerBlockExtension(
 	blockName,
-	{ attributes, classNameGenerator, Edit, extensionName },
+	{ attributes, classNameGenerator, Edit, extensionName, order = 'after' },
 ) {
 	const isMultiBlock = Array.isArray(blockName);
 
@@ -82,10 +83,17 @@ function registerBlockExtension(
 				return <BlockEdit {...props} />;
 			}
 
+			const shouldRenderBefore = order === 'before' && isSelected;
+			const shouldRenderAfter = order === 'after' && isSelected;
+
+			const shouldRenderFallback = !shouldRenderBefore && !shouldRenderAfter && isSelected;
+
 			return (
 				<>
+					{shouldRenderBefore && <Edit {...props} />}
 					<BlockEdit {...props} />
-					{isSelected && <Edit {...props} />}
+					{shouldRenderAfter && <Edit {...props} />}
+					{shouldRenderFallback && <Edit {...props} />}
 				</>
 			);
 		};

--- a/api/register-block-extension/readme.md
+++ b/api/register-block-extension/readme.md
@@ -55,6 +55,7 @@ registerBlockExtension(
   attributes: additionalAttributes,
   classNameGenerator: generateClassNames,
   Edit: BlockEdit,
+  order: 'before',
  }
 );
 ```
@@ -68,3 +69,4 @@ registerBlockExtension(
 | options.attributes         | `object`   | Block Attributes that should get added to the block |
 | options.classNameGenerator | `function` | Function that gets passed the attributes of the block to generate a class name string |
 | options.Edit               | `function` | BlockEdit component like in `registerBlockType` only without the actual block. So only using slots like the `InspectorControls` is advised. |
+| options.order               | `string` | The order in which the extension should be called in relation to the original BlockEdit component. Can be `before` or `after`. Defaults to `after` |


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

When Working with block extensions it is sometimes important to control whether a new setting should be called before the original component or after it. The default should stay rendering it after it, so that any new settings get rendered at the end of the Inspector Controls Slot for example. But there are instances where we need to render something at the beginning of the Slot which we can control with the order. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - A new order setting to the registerBlockExtension API


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
