### PR TITLE
Fix alignment of Popover in Link Component

### DIFF
--- a/components/link/index.js
+++ b/components/link/index.js
@@ -158,12 +158,7 @@ const Link = ({
 			)}
 
 			{isPopoverVisible && (
-				<Popover
-					position="bottom center"
-					anchorRef={linkRef.current}
-					ref={popoverRef}
-					focusOnMount={false}
-				>
+				<Popover anchorRef={linkRef.current} ref={popoverRef} focusOnMount={false}>
 					<LinkControl
 						hasTextControl
 						className="tenup-block-components-link__link-control"

--- a/components/link/index.js
+++ b/components/link/index.js
@@ -158,7 +158,12 @@ const Link = ({
 			)}
 
 			{isPopoverVisible && (
-				<Popover anchorRef={linkRef.current} ref={popoverRef} focusOnMount={false}>
+				<Popover
+					anchorRef={linkRef.current}
+					anchor={linkRef.current}
+					ref={popoverRef}
+					focusOnMount={false}
+				>
 					<LinkControl
 						hasTextControl
 						className="tenup-block-components-link__link-control"


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Starting in WordPress 6.1 the behavior of the Popover changes slightly and manually positioned popovers don't auto change their position. Therefore we are removing the manual placement in favor of full auto-placement to prevent overflow issues.

Before:

https://user-images.githubusercontent.com/20684594/195578720-3d07a546-9b5b-405c-9f13-f0f4545c6b38.mp4



After:

https://user-images.githubusercontent.com/20684594/195578731-dbee3c67-391c-4ed8-a76e-9f70723db87f.mp4




### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Positioning of Popover in Link Component


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
