### PR TITLE
Enhancement: Add `renderItemType` prop to `ContentSearch`

### DIFF
--- a/components/content-search/SearchItem.js
+++ b/components/content-search/SearchItem.js
@@ -49,13 +49,6 @@ const SearchItem = ({
 	const textContent = getTextContent(richTextContent);
 	const titleContent = decodeEntities(textContent);
 
-	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
-	let type = suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
-	// Allow type to be overriden by renderType
-	if (renderType) {
-		type = renderType(suggestion);
-	}
-
 	return (
 		<Tooltip text={decodeEntities(suggestion.title)}>
 			<ButtonStyled
@@ -89,7 +82,9 @@ const SearchItem = ({
 					</span>
 				</span>
 				{showType && (
-					<span className="block-editor-link-control__search-item-type">{type}</span>
+					<span className="block-editor-link-control__search-item-type">
+						{renderType(suggestion)}
+					</span>
 				)}
 			</ButtonStyled>
 		</Tooltip>
@@ -100,7 +95,10 @@ SearchItem.defaultProps = {
 	id: '',
 	searchTerm: '',
 	isSelected: false,
-	renderType: null,
+	renderType: (suggestion) => {
+		// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
+		return suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
+	},
 };
 
 SearchItem.propTypes = {

--- a/components/content-search/SearchItem.js
+++ b/components/content-search/SearchItem.js
@@ -31,14 +31,30 @@ const ButtonStyled = styled(Button)`
  * @param {string} props.searchTerm the search term
  * @param {boolean} props.isSelected whether the item is selected
  * @param {string} props.id the id of the item
+ * @param {Function} props.renderType a callback to override the type text
  * @returns {*} React JSX
  */
-const SearchItem = ({ suggestion, onClick, searchTerm, isSelected, id, contentTypes }) => {
+const SearchItem = ({
+	suggestion,
+	onClick,
+	searchTerm,
+	isSelected,
+	id,
+	contentTypes,
+	renderType,
+}) => {
 	const showType = suggestion.type && contentTypes.length > 1;
 
 	const richTextContent = create({ html: suggestion.title });
 	const textContent = getTextContent(richTextContent);
 	const titleContent = decodeEntities(textContent);
+
+	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
+	let type = suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
+	// Allow type to be overriden by renderType
+	if (renderType) {
+		type = renderType(suggestion);
+	}
 
 	return (
 		<Tooltip text={decodeEntities(suggestion.title)}>
@@ -73,10 +89,7 @@ const SearchItem = ({ suggestion, onClick, searchTerm, isSelected, id, contentTy
 					</span>
 				</span>
 				{showType && (
-					<span className="block-editor-link-control__search-item-type">
-						{/* Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label. */}
-						{suggestion.type === 'post_tag' ? 'tag' : suggestion.type}
-					</span>
+					<span className="block-editor-link-control__search-item-type">{type}</span>
 				)}
 			</ButtonStyled>
 		</Tooltip>
@@ -87,6 +100,7 @@ SearchItem.defaultProps = {
 	id: '',
 	searchTerm: '',
 	isSelected: false,
+	renderType: null,
 };
 
 SearchItem.propTypes = {
@@ -96,6 +110,7 @@ SearchItem.propTypes = {
 	onClick: PropTypes.func.isRequired,
 	isSelected: PropTypes.bool,
 	contentTypes: PropTypes.array.isRequired,
+	renderType: PropTypes.func,
 };
 
 export default SearchItem;

--- a/components/content-search/index.js
+++ b/components/content-search/index.js
@@ -22,6 +22,7 @@ const ContentSearch = ({
 	perPage,
 	queryFilter,
 	excludeItems,
+	renderItemType,
 }) => {
 	const [searchString, setSearchString] = useState('');
 	const [searchQueries, setSearchQueries] = useState({});
@@ -366,6 +367,7 @@ const ContentSearch = ({
 											suggestion={item}
 											contentTypes={contentTypes}
 											isSelected={selectedItem === index + 1}
+											renderType={renderItemType}
 										/>
 									</li>
 								);
@@ -406,6 +408,7 @@ ContentSearch.defaultProps = {
 	onSelectItem: () => {
 		console.log('Select!'); // eslint-disable-line no-console
 	},
+	renderItemType: null,
 };
 
 ContentSearch.propTypes = {
@@ -417,6 +420,7 @@ ContentSearch.propTypes = {
 	excludeItems: PropTypes.array,
 	label: PropTypes.string,
 	perPage: PropTypes.number,
+	renderItemType: PropTypes.func,
 };
 
 export { ContentSearch };

--- a/components/content-search/index.js
+++ b/components/content-search/index.js
@@ -408,7 +408,7 @@ ContentSearch.defaultProps = {
 	onSelectItem: () => {
 		console.log('Select!'); // eslint-disable-line no-console
 	},
-	renderItemType: null,
+	renderItemType: undefined,
 };
 
 ContentSearch.propTypes = {

--- a/components/content-search/readme.md
+++ b/components/content-search/readme.md
@@ -22,14 +22,15 @@ function MyComponent( props ) {
 
 ## Props
 
-| Name           | Type       | Default                              | Description                                                                                                                    |
-|----------------|------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `onSelectItem` | `function` | `undefined`                          | Function called when a searched item is clicked                                                                                |
-| `queryFilter`  | `function` | `(query, parametersObject) => query` | Function called to allow you to customize the query before is made. It's advisable to use `useCallback` to save this parameter |
-| `label`        | `string`   | `''`                                 | Renders a label for the Search Field.                                                                                          |
-| `mode`         | `string`   | `'post'`                             | One of: `post`, `user`, `term`                                                                                                 |
-| `placeholder`  | `string`   | `''`                                 | Renders placeholder text inside the Search Field.                                                                              |
-| `contentTypes` | `array`    | `[ 'post', 'page' ]`                 | Names of the post types or taxonomies that should get searched                                                                 |
-| `excludeItems` | `array`    | `[ { id: 1, type: 'post' ]`          | Items to exclude from search                                                                                                   |
-| `perPage`      | `number`   | `50`                                 | Number of items to show during search                                                                                          |
+| Name             | Type       | Default                              | Description                                                                                                                    |
+|------------------|------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `onSelectItem`   | `function` | `undefined`                          | Function called when a searched item is clicked                                                                                |
+| `queryFilter`    | `function` | `(query, parametersObject) => query` | Function called to allow you to customize the query before is made. It's advisable to use `useCallback` to save this parameter |
+| `label`          | `string`   | `''`                                 | Renders a label for the Search Field.                                                                                          |
+| `mode`           | `string`   | `'post'`                             | One of: `post`, `user`, `term`                                                                                                 |
+| `placeholder`    | `string`   | `''`                                 | Renders placeholder text inside the Search Field.                                                                              |
+| `contentTypes`   | `array`    | `[ 'post', 'page' ]`                 | Names of the post types or taxonomies that should get searched                                                                 |
+| `excludeItems`   | `array`    | `[ { id: 1, type: 'post' ]`          | Items to exclude from search                                                                                                   |
+| `perPage`        | `number`   | `50`                                 | Number of items to show during search                                                                                          |
+| `renderItemType` | `function` | `null`                               | Function called to override the item type label in `SearchItem`. Must return the new label.                                                                                      |
 

--- a/components/content-search/readme.md
+++ b/components/content-search/readme.md
@@ -32,5 +32,5 @@ function MyComponent( props ) {
 | `contentTypes`   | `array`    | `[ 'post', 'page' ]`                 | Names of the post types or taxonomies that should get searched                                                                 |
 | `excludeItems`   | `array`    | `[ { id: 1, type: 'post' ]`          | Items to exclude from search                                                                                                   |
 | `perPage`        | `number`   | `50`                                 | Number of items to show during search                                                                                          |
-| `renderItemType` | `function` | `null`                               | Function called to override the item type label in `SearchItem`. Must return the new label.                                                                                      |
+| `renderItemType` | `function` | `undefined`                          | Function called to override the item type label in `SearchItem`. Must return the new label.                                                                                      |
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Adds a callback to allow customisation of the item type in the suggestions list.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #160 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Add the `renderItemType` prop to the `ContentSearch` component.
```jsx
<ContentSearch
	{ ...props }
	renderItemType={ ( suggestion ) => {
		return suggestion.subtype;
	} }
/>
```

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature - customise the item type rendered in the ContentSearch component.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.


_I had trouble creating the dev environment so couldn't spin up the tests._ 