### PR TITLE
Update readme.md example of link component

### DIFF
--- a/components/link/readme.md
+++ b/components/link/readme.md
@@ -15,7 +15,7 @@ const BlockEdit = (props) => {
 
     const blockProps = useBlockProps();
 
-    const handleTextChange = value => setAttributes({text: value});
+    const handleTextChange = value => setAttributes({linkText: value});
     const handleLinkChange = value => setAttributes({
         linkUrl: value?.url,
         opensInNewTab: value?.opensInNewTab,


### PR DESCRIPTION
Repalces 'text' with 'linkText' in props change; I was reusing the code example here and didn't notice that I wasn't updating the component props when editing the link in the editor instead of the popup.