### PR TITLE
Doc updated: Image component Focal Picker needs default settings

### DIFF
--- a/components/image/readme.md
+++ b/components/image/readme.md
@@ -42,9 +42,9 @@ function BlockEdit(props) {
 
 | Name       | Type              | Default  |  Description                                                   |
 | ---------- | ----------------- | -------- | -------------------------------------------------------------- |
-| `id` | `number`    | `null`   | image id          |
+| `id` | `number`    | `null`   | Image ID          |
 | `onSelect` | `Function` | `null` | Callback that gets called with the new image when one is selected |
-| `size` | `string` | `large` | name of the image size to be displayed |
-| `focalPoint` | `object` | `undefined` | optional focal point object |
+| `size` | `string` | `large` | Name of the image size to be displayed |
+| `focalPoint` | `object` | `undefined` | Optional focal point object. Default settings must be added when used. |
 | `onChangeFocalPoint` | `function` | `undefined` | Callback that gets called with the new focal point when it changes |
-| `...rest` | `*` | `null` | any additional attributes you want to pass to the underlying `img` tag |
+| `...rest` | `*` | `null` | Any additional attributes you want to pass to the underlying `img` tag |


### PR DESCRIPTION
### Description of the Change
This PR simply adds a note in the readme file for the image block component that default settings must be added when a `focalPoint` is used. Also capitalizes the first character in the description column.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #182

### How to test the Change
1. Add component as outlined in the [readme](https://github.com/10up/block-components/blob/develop/components/image/readme.md)
2. Add your attributes to block.json
```
{
  ...
  "attributes": {
    "imageId": {
      "type": "number"
    },
    "focalPoint": {
      "type": "object"
    }
  }
}
```
3. See that the Focal Picker should render.

### Changelog Entry
> Updated - Document for an image component, mentioned that a focal picker needs default settings when used.

### Credits
Props @colinswinney @faisal-alvi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
