### PR TITLE
fix pass fallback value to focal point picker if value is undefined

### DIFF
--- a/components/image/index.js
+++ b/components/image/index.js
@@ -10,19 +10,14 @@ const Image = (props) => {
 		id,
 		size = 'full',
 		onSelect,
-		focalPoint = undefined,
+		focalPoint = { x: 0.5, y: 0.5 },
 		onChangeFocalPoint,
 		...rest
 	} = props;
 	const hasImage = !!id;
 	const { media, isResolvingMedia } = useMedia(id);
 
-	const hasFocalPoint = !!focalPoint;
-
-	if (hasFocalPoint && typeof onChangeFocalPoint !== 'function') {
-		// eslint-disable-next-line no-console
-		console.warn('onChangeFocalPoint is required when focalPoint is set');
-	}
+	const shouldDisplayFocalPointPicker = typeof onChangeFocalPoint !== 'function';
 
 	if (!hasImage) {
 		return <MediaPlaceholder onSelect={onSelect} accept="image" multiple={false} />;
@@ -35,7 +30,7 @@ const Image = (props) => {
 	const imageUrl = media?.media_details?.sizes[size]?.source_url ?? media?.source_url;
 	const altText = media?.alt_text;
 
-	if (hasFocalPoint) {
+	if (shouldDisplayFocalPointPicker) {
 		const focalPointStyle = {
 			objectFit: 'cover',
 			objectPosition: `${focalPoint.x * 100}% ${focalPoint.y * 100}%`,
@@ -49,13 +44,13 @@ const Image = (props) => {
 
 	return (
 		<>
-			{hasFocalPoint && (
+			{shouldDisplayFocalPointPicker && (
 				<InspectorControls>
 					<PanelBody title={__('Image Settings')}>
 						<FocalPointPicker
 							label={__('Focal Point Picker')}
 							url={imageUrl}
-							value={focalPoint || { x: 0.5, y: 0.5 }}
+							value={focalPoint}
 							onChange={onChangeFocalPoint}
 						/>
 					</PanelBody>
@@ -70,7 +65,7 @@ export { Image };
 
 Image.defaultProps = {
 	size: 'large',
-	focalPoint: undefined,
+	focalPoint: { x: 0.5, y: 0.5 },
 	onChangeFocalPoint: undefined,
 };
 

--- a/components/image/index.js
+++ b/components/image/index.js
@@ -55,7 +55,7 @@ const Image = (props) => {
 						<FocalPointPicker
 							label={__('Focal Point Picker')}
 							url={imageUrl}
-							value={focalPoint}
+							value={focalPoint || { x: 0.5, y: 0.5 }}
 							onChange={onChangeFocalPoint}
 						/>
 					</PanelBody>

--- a/components/image/readme.md
+++ b/components/image/readme.md
@@ -37,7 +37,6 @@ function BlockEdit(props) {
 > **Note**
 > In order to get the same result as the GIF you also need to use the [`MediaToolbar`](https://github.com/10up/block-components/tree/develop/components/media-toolbar) component. It adds the Replace flow to the Blocks Toolbar.
 
-
 ## Props
 
 | Name       | Type              | Default  |  Description                                                   |
@@ -45,6 +44,6 @@ function BlockEdit(props) {
 | `id` | `number`    | `null`   | Image ID          |
 | `onSelect` | `Function` | `null` | Callback that gets called with the new image when one is selected |
 | `size` | `string` | `large` | Name of the image size to be displayed |
-| `focalPoint` | `object` | `undefined` | Optional focal point object. Default settings must be added when used. |
-| `onChangeFocalPoint` | `function` | `undefined` | Callback that gets called with the new focal point when it changes |
+| `focalPoint` | `object` | `{x:0.5,y:0.5}` | Optional focal point object.
+| `onChangeFocalPoint` | `function` | `undefined` | Callback that gets called with the new focal point when it changes. (Is required for the FocalPointPicker to appear) |
 | `...rest` | `*` | `null` | Any additional attributes you want to pass to the underlying `img` tag |


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Pass a default value of `{ x: 0.5, y: 0.5 }` to the `FocalPointPicker` if the `value` is `undefined`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #182

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Create a block that uses the image component with the focal point options and don't pass it a focal point value to it

### Changelog Entry

Fixed: FocalPointPicker not rendering when no default value is provided

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ncoetzer, @colinswinney 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
