### PR TITLE
Only output icon if one is set

### DIFF
--- a/components/icon-picker/icon-picker-toolbar-button.js
+++ b/components/icon-picker/icon-picker-toolbar-button.js
@@ -26,17 +26,15 @@ export const IconPickerToolbarButton = (props) => {
 		buttonLabel,
 	} = props;
 
+	const buttonIcon = name && iconSet ? <Icon name={name} iconSet={iconSet} /> : null;
+
 	return (
 		<Dropdown
 			className="component-icon-picker-toolbar-button"
 			contentClassName="component-icon-picker-toolbar-button__content"
 			position="bottom right"
 			renderToggle={({ isOpen, onToggle }) => (
-				<ToolbarButton
-					onClick={onToggle}
-					aria-expanded={isOpen}
-					icon={<Icon name={name} iconSet={iconSet} />}
-				>
+				<ToolbarButton onClick={onToggle} aria-expanded={isOpen} icon={buttonIcon}>
 					{buttonLabel ?? __('Select Icon')}
 				</ToolbarButton>
 			)}


### PR DESCRIPTION
### Description of the Change
In UI Kit, we were just getting a spinner in the icon toolbar dropdown when none was set. This fixes that problem.


### How to test the Change
Confirm if no icon is set, there is no spinner in the toolbar.

### Changelog Entry
- Don't output icon if none is set in toolbar

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
