### PR TITLE
spread additional props passed to link component through to rich text component

### DIFF
--- a/components/link/index.js
+++ b/components/link/index.js
@@ -87,7 +87,7 @@ const StylesRichTextLink = styled(RichText)`
  * The link should not be visible if the block is not focused. This will maintain nicer
  * visuals in the block editor as a whole.
  *
- * @param {object} props								All properties passed to the component.
+ * @param {...object} props								All properties passed to the component.
  * @param {string} props.value 							The text to show inside the link
  * @param {string} props.type 							Post or Page, used to autosuggest content for URL
  * @param {boolean} props.opensInNewTab 				Should the link open in a new tab?
@@ -98,7 +98,6 @@ const StylesRichTextLink = styled(RichText)`
  * @param {string} props.kind 							Page or Post
  * @param {string} props.placeholder 					Text visible before actual value is inserted
  * @param {string} props.className 					    html class to be applied to the anchor element
- * @param {object} rest 								All other properties passed to the component.
  *
  * @returns {*} The rendered component.
  */

--- a/components/link/index.js
+++ b/components/link/index.js
@@ -98,6 +98,7 @@ const StylesRichTextLink = styled(RichText)`
  * @param {string} props.kind 							Page or Post
  * @param {string} props.placeholder 					Text visible before actual value is inserted
  * @param {string} props.className 					    html class to be applied to the anchor element
+ * @param {object} rest 								All other properties passed to the component.
  *
  * @returns {*} The rendered component.
  */
@@ -112,6 +113,7 @@ const Link = ({
 	kind,
 	placeholder,
 	className,
+	...rest
 }) => {
 	const [isPopoverVisible, setIsPopoverVisible] = useState(false);
 	const [isValidLink, setIsValidLink] = useState(false);
@@ -149,6 +151,7 @@ const Link = ({
 				allowedFormats={[]}
 				onClick={openPopover}
 				ref={linkRef}
+				{...rest}
 			/>
 
 			{!isValidLink && (

--- a/components/link/readme.md
+++ b/components/link/readme.md
@@ -59,3 +59,4 @@ The `<RichText>` node will only render when BlockEdit is selected.
 |  `kind` | `string` | `""` |        Page or Post |
 |  `placeholder` | `string` | `Link text ...` |      Text visible before actual value is inserted |
 |  `className` | `string` | `undefined` |          html class to be applied to the anchor element |
+|  `...rest` | `object` | `{}` | pass through any additional props to the RichText component used for the link element |


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This passes on any additional props given to the `Link` component through to the underlying `RichText` component. Therefore it allows to further modify the behavior of the `RichText` component.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Try adding additional props like `onSplit` to the `Link` component.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - spread additional props passed to link component through to rich text component


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
