### PR TITLE
fix how class names from core get passed through register block extension

### DIFF
--- a/api/register-block-extension/index.js
+++ b/api/register-block-extension/index.js
@@ -3,6 +3,7 @@
 
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import classnames from 'classnames';
 
 /**
  * registerBlockExtension
@@ -110,7 +111,7 @@ function registerBlockExtension(
 	 */
 	const addClassNameInEditor = createHigherOrderComponent((BlockList) => {
 		return (props) => {
-			const { name, attributes } = props;
+			const { name, attributes, className } = props;
 
 			// return early from the block modification
 			if (!shouldApplyBlockExtension(name)) {
@@ -123,12 +124,9 @@ function registerBlockExtension(
 				return <BlockList {...props} />;
 			}
 
-			return (
-				<BlockList
-					{...props}
-					className={`${attributes.className || ''} ${additionalClassName}`}
-				/>
-			);
+			const newClassName = classnames(className, additionalClassName);
+
+			return <BlockList {...props} className={newClassName} />;
 		};
 	}, 'addClassNameInEditor');
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

When filtering the `editor.BlockListBlock` to add a custom class name to it we need to ensure we correctly pipe through any already existing classes. This was done incorrectly. You can see an example of how core does it here: Here is an example of how it is done in core: https://github.com/WordPress/gutenberg/blob/70ba9218ae53e31d2c26689eed2e698dcea7f3aa/packages/block-editor/src/hooks/layout.js#L457-L460

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

All tests should pass

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Make sure any class names which get added via `editor.BlockListBlock` filter get passed through correctly


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
