### PR TITLE
fix add back inline default value to prevent undefined error

### DIFF
--- a/components/author/index.js
+++ b/components/author/index.js
@@ -22,7 +22,7 @@ import { AuthorContext } from './context';
  */
 
 export const Name = (props) => {
-	const { tagName: TagName, ...rest } = props;
+	const { tagName: TagName = 'span', ...rest } = props;
 
 	/**
 	 * @type {Author}
@@ -47,7 +47,7 @@ Name.defaultProps = {
 };
 
 export const FirstName = (props) => {
-	const { tagName: TagName, ...rest } = props;
+	const { tagName: TagName = 'span', ...rest } = props;
 
 	/**
 	 * @type {Author}
@@ -66,7 +66,7 @@ FirstName.defaultProps = {
 };
 
 export const LastName = (props) => {
-	const { tagName: TagName, ...rest } = props;
+	const { tagName: TagName = 'span', ...rest } = props;
 
 	/**
 	 * @type {Author}

--- a/components/post-date/index.js
+++ b/components/post-date/index.js
@@ -28,7 +28,7 @@ PostDatePicker.propTypes = {
 };
 
 export const PostDate = (props) => {
-	const { placeholder, format, ...rest } = props;
+	const { placeholder = __('No date set', 'tenup'), format, ...rest } = props;
 
 	const { postId, postType, isEditable } = usePost();
 

--- a/components/post-excerpt/index.js
+++ b/components/post-excerpt/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { usePost } from '../../hooks';
 
 export const PostExcerpt = (props) => {
-	const { placeholder, ...rest } = props;
+	const { placeholder = __('Enter excerpt...', 'tenup'), ...rest } = props;
 	const { postId, postType, isEditable } = usePost();
 
 	const [rawExcerpt = '', setExcerpt, fullExcerpt] = useEntityProp(

--- a/components/post-meta/index.js
+++ b/components/post-meta/index.js
@@ -29,7 +29,7 @@ PostMeta.propTypes = {
 };
 
 const MetaString = (props) => {
-	const { metaKey, tagName } = props;
+	const { metaKey, tagName = 'p' } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue(metaKey);
 
 	return <RichText value={metaValue} onChange={setMetaValue} tagName={tagName} {...props} />;

--- a/components/post-primary-term/index.js
+++ b/components/post-primary-term/index.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import { usePrimaryTerm } from '../../hooks';
 
 export const PostPrimaryTerm = (props) => {
-	const { taxonomyName, placeholder, isLink, ...rest } = props;
+	const {
+		taxonomyName = 'category',
+		placeholder = __('Select a term', 'tenup'),
+		isLink = true,
+		...rest
+	} = props;
 
 	const [primaryTerm, isSupportedTaxonomy] = usePrimaryTerm(taxonomyName);
 

--- a/components/post-term-list/index.js
+++ b/components/post-term-list/index.js
@@ -11,7 +11,7 @@ import { PostTermContext } from './context';
 import { ListItem, TermLink } from './item';
 
 export const PostTermList = (props) => {
-	const { tagName: TagName, taxonomyName, children, ...rest } = props;
+	const { tagName: TagName = 'ul', taxonomyName, children, ...rest } = props;
 
 	const { isEditable } = usePost();
 

--- a/components/post-term-list/item.js
+++ b/components/post-term-list/item.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { PostTermContext } from './context';
 
 export const ListItem = (props) => {
-	const { tagName: TagName, children, ...rest } = props;
+	const { tagName: TagName = 'li', children, ...rest } = props;
 
 	return <TagName {...rest}>{children}</TagName>;
 };

--- a/components/post-title/index.js
+++ b/components/post-title/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { usePost } from '../../hooks';
 
 export const PostTitle = (props) => {
-	const { tagName: TagName, ...rest } = props;
+	const { tagName: TagName = 'h1', ...rest } = props;
 	const { postId, postType, isEditable } = usePost();
 
 	const [rawTitle = '', setTitle, fullTitle] = useEntityProp(


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

For whatever unexplained reason, the `defaultProps` declaration does not get applied at runtime, causing the default values getting defined via them to not apply. Since we are switching away from PropTypes to TypeScript eventually, this isn't a large issue. For now, we duplicate the default value in both places. 


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Try and use the `Hero` block in a post and add some terms to it.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Missing inline default props value causing undefined getting passed as a react component tag name


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy @Antonio-Laguna 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
