### PR TITLE
Improving stability across renders

### DIFF
--- a/hooks/use-popover/index.js
+++ b/hooks/use-popover/index.js
@@ -32,7 +32,7 @@ export const usePopover = () => {
 					</Popover>
 				);
 			},
-		[isVisible, popoverAnchor],
+		[isVisible, popoverAnchor, ref],
 	);
 
 	return {

--- a/hooks/use-popover/index.js
+++ b/hooks/use-popover/index.js
@@ -1,5 +1,5 @@
 import { Popover } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useCallback, useMemo } from '@wordpress/element';
 import { useOnClickOutside } from '../use-on-click-outside';
 
 export const usePopover = () => {
@@ -7,9 +7,9 @@ export const usePopover = () => {
 	// re-renders when the popover's anchor updates.
 	const [popoverAnchor, setPopoverAnchor] = useState();
 	const [isVisible, setIsVisible] = useState(false);
-	const toggleVisible = () => {
-		setIsVisible(!isVisible);
-	};
+	const toggleVisible = useCallback(() => {
+		setIsVisible((visible) => !visible);
+	}, []);
 
 	const toggleProps = {
 		onClick: toggleVisible,
@@ -18,17 +18,27 @@ export const usePopover = () => {
 	};
 
 	const ref = useOnClickOutside(() => setIsVisible(false));
+	const PopoverComponent = useMemo(
+		() =>
+			// eslint-disable-next-line react/prop-types
+			({ children }) => {
+				if (!isVisible) {
+					return null;
+				}
+
+				return (
+					<Popover ref={ref} anchor={popoverAnchor} focusOnMount={false} animate={false}>
+						<div style={{ padding: '16px', minWidth: '250px' }}>{children}</div>
+					</Popover>
+				);
+			},
+		[isVisible, popoverAnchor],
+	);
 
 	return {
 		setPopoverAnchor,
 		toggleVisible,
 		toggleProps,
-		// eslint-disable-next-line react/prop-types
-		Popover: ({ children }) =>
-			isVisible ? (
-				<Popover ref={ref} anchor={popoverAnchor} focusOnMount={false} animate={false}>
-					<div style={{ padding: '16px', minWidth: '250px' }}>{children}</div>
-				</Popover>
-			) : null,
+		Popover: PopoverComponent,
 	};
 };


### PR DESCRIPTION
Fixes #200

Returning components from a hook is usually a bad idea. The reason is that hooks run on every render which, in this case, leads to a new `Popover` ( the WP's one ) being created. 

React tears down all its children and replaces them with new ones which cause the focus to be lost. 

So every time a component using `usePopover` renders it will tear down all the children of `<Popover>` and rebuild them because `<Popover>` is a "new" function component.

By switching to `useMemo` we're telling React to hold onto that function unless `[isVisible, popoverAnchor, ref]` changes which is what we actually want. Note that `ref` is only added to make ESLint happy, refs are stable across render and .they will never trigger a re-render


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
