### PR TITLE
Add the ability to define a "noResultsMessage" on the PostTermList component

### DIFF
--- a/components/optional/index.js
+++ b/components/optional/index.js
@@ -11,6 +11,6 @@ Optional.defaultProps = {
 };
 
 Optional.propTypes = {
-	value: PropTypes.string,
+	value: PropTypes.string || PropTypes.bool,
 	children: PropTypes.node.isRequired,
 };

--- a/components/post-category-list/index.js
+++ b/components/post-category-list/index.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 import { PostTermList } from '../post-term-list';
 
 export const PostCategoryList = PostTermList;
@@ -9,4 +10,5 @@ PostCategoryList.propTypes = {
 
 PostCategoryList.defaultProps = {
 	taxonomyName: 'category',
+	noResultsMessage: __('Please select a category', 'tenup'),
 };

--- a/components/post-term-list/index.js
+++ b/components/post-term-list/index.js
@@ -68,7 +68,9 @@ export const PostTermList = (props) => {
 								</PostTermContext.Provider>
 							))
 						) : (
-							<i>{noResultsMessage}</i>
+							<li>
+								<i>{noResultsMessage}</i>
+							</li>
 						)}
 					</TagName>
 				</Optional>
@@ -92,7 +94,9 @@ export const PostTermList = (props) => {
 							</li>
 						))
 					) : (
-						<i>{noResultsMessage}</i>
+						<li>
+							<i>{noResultsMessage}</i>
+						</li>
 					)}
 				</TagName>
 			</Optional>

--- a/components/post-term-list/index.js
+++ b/components/post-term-list/index.js
@@ -1,5 +1,6 @@
 import { Spinner } from '@wordpress/components';
 import { Children } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import {
 	PostTaxonomiesHierarchicalTermSelector,
@@ -7,11 +8,18 @@ import {
 } from '@wordpress/editor';
 
 import { usePopover, usePost, useSelectedTerms, useTaxonomy } from '../../hooks';
+import { Optional } from '..';
 import { PostTermContext } from './context';
 import { ListItem, TermLink } from './item';
 
 export const PostTermList = (props) => {
-	const { tagName: TagName = 'ul', taxonomyName, children, ...rest } = props;
+	const {
+		tagName: TagName = 'ul',
+		taxonomyName,
+		children,
+		noResultsMessage = __('Please select a term', 'tenup'),
+		...rest
+	} = props;
 
 	const { isEditable } = usePost();
 
@@ -46,16 +54,24 @@ export const PostTermList = (props) => {
 		};
 	}
 
+	const hasSelectedTerms = selectedTerms.length > 0;
+
 	if (hasChildComponents) {
 		return (
 			<>
-				<TagName {...listElementProps}>
-					{selectedTerms.map((term) => (
-						<PostTermContext.Provider value={term} key={term.id}>
-							{children}
-						</PostTermContext.Provider>
-					))}
-				</TagName>
+				<Optional value={hasSelectedTerms}>
+					<TagName {...listElementProps}>
+						{hasSelectedTerms ? (
+							selectedTerms.map((term) => (
+								<PostTermContext.Provider value={term} key={term.id}>
+									{children}
+								</PostTermContext.Provider>
+							))
+						) : (
+							<i>{noResultsMessage}</i>
+						)}
+					</TagName>
+				</Optional>
 				{isEditable && (
 					<Popover>
 						<PostTaxonomiesTermSelector slug={taxonomyName} />
@@ -67,13 +83,19 @@ export const PostTermList = (props) => {
 
 	return (
 		<>
-			<TagName {...listElementProps}>
-				{selectedTerms.map((term) => (
-					<li key={term.id}>
-						<a href={term.link}>{term.name}</a>
-					</li>
-				))}
-			</TagName>
+			<Optional value={hasSelectedTerms}>
+				<TagName {...listElementProps}>
+					{hasSelectedTerms ? (
+						selectedTerms.map((term) => (
+							<li key={term.id}>
+								<a href={term.link}>{term.name}</a>
+							</li>
+						))
+					) : (
+						<i>{noResultsMessage}</i>
+					)}
+				</TagName>
+			</Optional>
 			{isEditable && (
 				<Popover>
 					<PostTaxonomiesTermSelector slug={taxonomyName} />
@@ -87,12 +109,14 @@ PostTermList.propTypes = {
 	children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 	taxonomyName: PropTypes.string,
 	tagName: PropTypes.string,
+	noResultsMessage: PropTypes.string,
 };
 
 PostTermList.defaultProps = {
 	children: null,
 	tagName: 'ul',
 	taxonomyName: 'category',
+	noResultsMessage: __('Please select a term', 'tenup'),
 };
 
 PostTermList.ListItem = ListItem;

--- a/components/post-term-list/readme.md
+++ b/components/post-term-list/readme.md
@@ -38,6 +38,7 @@ function BlockEdit() {
 | `context` | `object` | `{}` |  |
 | `children` | `function\|node\|null`  | `null` |  |
 | `taxonomyName` | `string` | `category` |  |
+| `noResultsMessage` | `string` | `Please select a term` |  |
 | `tagName` | `string` | `ul` |  |
 | `...rest` | `object` | `{}` |  |
 

--- a/example/src/blocks/hero/index.js
+++ b/example/src/blocks/hero/index.js
@@ -3,7 +3,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { header } from '@wordpress/icons';
 
-import { PostFeaturedImage, PostTitle, PostPrimaryCategory, PostDate, PostCategoryList, PostAuthor, PostExcerpt } from '@10up/block-components';
+import { PostFeaturedImage, PostTitle, PostPrimaryCategory, PostDate, PostCategoryList, PostTermList, PostAuthor, PostExcerpt } from '@10up/block-components';
 
 const NAMESPACE = 'example';
 
@@ -35,6 +35,11 @@ registerBlockType(`${NAMESPACE}/hero`, {
 						<PostCategoryList.TermLink className="wp-block-example-hero__category-link" />
 					</PostCategoryList.ListItem>
 				</PostCategoryList>
+				<PostTermList taxonomyName="post_tag" className="wp-block-example-hero__tags">
+					<PostTermList.ListItem className="wp-block-example-hero__tag">
+						<PostTermList.TermLink className="wp-block-example-hero__tag-link" />
+					</PostTermList.ListItem>
+				</PostTermList>
 				<PostDate className="wp-block-example-hero__date" />
 				<PostExcerpt className="wp-block-example-hero__excerpt" />
 				<PostAuthor className="wp-block-example-hero__author">


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Currently the `PostTermList` just renders completely empty if no terms are assigned to the post. This leads to a bad experience for the user because they are not able to user the inline control to select new terms. In order to fix this I've added a `noResultsMessage` prop to the component which has a default value.

I've also changed it so that the component only renders the no results message if the block this component is being used within also is currently selected. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Ability to define `noResultsMessage` on `PostTermList` component


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
