### PR TITLE
add action to monitor WordPress dependencies

### DIFF
--- a/.github/workflows/monitor-wordpress-dependencies.yml
+++ b/.github/workflows/monitor-wordpress-dependencies.yml
@@ -1,0 +1,15 @@
+name: WordPress Dependencies
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 16.x
+      - uses: fabiankaegy/monitor-wordpress-dependencies-action@v1.0.1
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          pattern: '**/*.asset.php'
+          exclude: ''


### PR DESCRIPTION
Add a GitHub Action that tracks changes of the Dependencies generated by the DependencyExtractionWebpackPlugin