### PR TITLE
add helper to handle non supported meta values

### DIFF
--- a/components/post-meta/index.js
+++ b/components/post-meta/index.js
@@ -1,13 +1,20 @@
 import { RichText } from '@wordpress/block-editor';
 import { __experimentalNumberControl as NumberControl, ToggleControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
-import { usePostMetaValue } from '../../hooks';
+import { usePostMetaValue, useIsSupportedMetaField } from '../../hooks';
 import { toSentence } from './utilities';
 
 export const PostMeta = (props) => {
 	const { metaKey, children } = props;
+	const [isSupported] = useIsSupportedMetaField(metaKey);
 	const [metaValue, setMetaValue] = usePostMetaValue(metaKey);
 	const metaValueType = typeof metaValue;
+
+	if (!isSupported) {
+		return (
+			<p className="tenup-block-components-post-meta-placeholder">{`${metaKey} - Meta Value`}</p>
+		);
+	}
 
 	if (typeof children === 'function') {
 		return children(metaValue, setMetaValue);

--- a/example/src/blocks/post-meta/index.js
+++ b/example/src/blocks/post-meta/index.js
@@ -2,7 +2,7 @@ import { registerBlockType, registerBlockVariation, store as blocksStore, create
 import {
 	useBlockProps, __experimentalBlockVariationPicker as BlockVariationPicker, store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { select, subscribe, useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { PostMeta } from '@10up/block-components';
 import { box } from '@wordpress/icons';
 
@@ -102,32 +102,22 @@ registerBlockType(metadata, {
 	save: () => null
 })
 
-let availableKeys = [];
-subscribe(() => {
-	const meta = select('core/editor').getCurrentPostAttribute('meta');
-	if (!meta) {
-		return;
-	}
+let availableKeys = [
+	"author",
+	"isbn",
+	"price",
+	"is_featured",
+];
 
-	const keys = Object.keys(meta);
+const newVariations = availableKeys.map(metaKey => ({
+	title: toSentence(metaKey) + ' - Meta',
+	description: `Displays the value of the meta key: "${metaKey}"`,
+	name: metaKey,
+	scope: ['inserter', 'block'],
+	attributes: {
+		metaKey: metaKey
+	},
+	isActive: ['metaKey']
+}));
 
-	if (JSON.stringify(keys) === JSON.stringify(availableKeys)) {
-		return;
-	}
-
-	availableKeys = keys;
-
-	const newVariations = availableKeys.map(metaKey => ({
-		title: toSentence(metaKey) + ' - Meta',
-		description: `Displays the value of the meta key: "${metaKey}"`,
-		name: metaKey,
-		scope: ['inserter', 'block'],
-		attributes: {
-			metaKey: metaKey
-		},
-		isActive: ['metaKey']
-	}));
-
-	registerBlockVariation('example/post-meta', newVariations);
-
-});
+registerBlockVariation('example/post-meta', newVariations);

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -16,3 +16,4 @@ export { usePopover } from './use-popover';
 export { useScript } from './use-script';
 export { usePostMetaValue } from './use-post-meta-value';
 export { useTaxonomy } from './use-taxonomy';
+export { useIsSupportedMetaField } from './use-is-supported-meta-value';

--- a/hooks/use-is-supported-meta-value/index.js
+++ b/hooks/use-is-supported-meta-value/index.js
@@ -1,0 +1,14 @@
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+export const useIsSupportedMetaField = (metaKey) => {
+	return useSelect(
+		(select) => {
+			const meta = select(editorStore).getCurrentPostAttribute('meta');
+			const supportedMetaKeys = Object.keys(meta || {});
+			const isSupportedMetaField = supportedMetaKeys?.some((name) => name === metaKey);
+			return [!!isSupportedMetaField];
+		},
+		[metaKey],
+	);
+};


### PR DESCRIPTION
When working with post meta values we can run into cases where a Post Type doesn't support the meta value. This however also is the case when you use the post-meta component within a query loop or a general template. So this handling shows a placeholder instead when that is the case. 