### PR TITLE
Fix render stability of IconPicker grid and update usage of deprecated Dropdown property

### DIFF
--- a/components/icon-picker/icon-picker-toolbar-button.js
+++ b/components/icon-picker/icon-picker-toolbar-button.js
@@ -32,7 +32,9 @@ export const IconPickerToolbarButton = (props) => {
 		<Dropdown
 			className="component-icon-picker-toolbar-button"
 			contentClassName="component-icon-picker-toolbar-button__content"
-			position="bottom right"
+			popoverProps={{
+				placement: 'bottom-start',
+			}}
 			renderToggle={({ isOpen, onToggle }) => (
 				<ToolbarButton onClick={onToggle} aria-expanded={isOpen} icon={buttonIcon}>
 					{buttonLabel ?? __('Select Icon')}

--- a/components/icon-picker/icon-picker-toolbar-button.js
+++ b/components/icon-picker/icon-picker-toolbar-button.js
@@ -21,12 +21,10 @@ const StyledIconPickerDropdown = styled(IconPicker)`
  * @returns {*}
  */
 export const IconPickerToolbarButton = (props) => {
-	const {
-		value: { name, iconSet },
-		buttonLabel,
-	} = props;
+	const { value, buttonLabel } = props;
 
-	const buttonIcon = name && iconSet ? <Icon name={name} iconSet={iconSet} /> : null;
+	const buttonIcon =
+		value?.name && value?.iconSet ? <Icon name={value?.name} iconSet={value?.iconSet} /> : null;
 
 	return (
 		<Dropdown

--- a/components/icon-picker/icon-picker.js
+++ b/components/icon-picker/icon-picker.js
@@ -145,7 +145,7 @@ const IconGrid = (props) => {
 		<StyledIconGrid orientation="vertical" className="component-icon-picker__list">
 			{icons.map((icon) => {
 				const isChecked =
-					selectedIcon?.name === icon.name && selectedIcon?.iconSet === icon.iconSet;
+					selectedIcon?.name === icon?.name && selectedIcon?.iconSet === icon?.iconSet;
 
 				return (
 					<CheckboxControl

--- a/components/icon-picker/icon-picker.js
+++ b/components/icon-picker/icon-picker.js
@@ -35,9 +35,9 @@ const StyledIconGrid = styled(NavigableMenu)`
 `;
 
 const StyledIconButton = styled(Icon)`
-	background-color: ${({ isSelected }) => (isSelected ? 'black' : 'white')};
-	color: ${({ isSelected }) => (isSelected ? 'white' : 'black')};
-	fill: ${({ isSelected }) => (isSelected ? 'white' : 'black')};
+	background-color: ${({ selected }) => (selected ? 'black' : 'white')};
+	color: ${({ selected }) => (selected ? 'white' : 'black')};
+	fill: ${({ selected }) => (selected ? 'white' : 'black')};
 	padding: 5px;
 	border: none;
 	border-radius: 4px;
@@ -48,7 +48,7 @@ const StyledIconButton = styled(Icon)`
 	justify-content: center;
 
 	&:hover {
-		background-color: ${({ isSelected }) => (isSelected ? '#555D66' : '#f3f4f5')};
+		background-color: ${({ selected }) => (selected ? '#555D66' : '#f3f4f5')};
 	}
 
 	& svg {
@@ -123,7 +123,7 @@ const IconLabel = (props) => {
 	return (
 		<>
 			<StyledIconButton
-				isSelected={isChecked}
+				selected={isChecked}
 				key={icon.name}
 				name={icon.name}
 				iconSet={icon.iconSet}

--- a/components/icon-picker/icon-picker.js
+++ b/components/icon-picker/icon-picker.js
@@ -10,7 +10,7 @@ import {
 	SearchControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useState, memo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 import { useIcons } from '../../hooks/use-icons';
 import { useFilteredList } from '../../hooks/use-filtered-list';
@@ -108,6 +108,36 @@ IconPicker.propTypes = {
 	label: PropTypes.string,
 };
 
+/**
+ * IconLabel
+ *
+ * @typedef IconLabelProps
+ * @property {object} icon icon object
+ * @property {boolean} isChecked whether the icon is checked
+ *
+ * @param {IconLabelProps} props IconLabel Props
+ * @returns {*} React Element
+ */
+const IconLabel = (props) => {
+	const { icon, isChecked } = props;
+	return (
+		<>
+			<StyledIconButton
+				isSelected={isChecked}
+				key={icon.name}
+				name={icon.name}
+				iconSet={icon.iconSet}
+			/>
+			<VisuallyHidden>{icon.label}</VisuallyHidden>
+		</>
+	);
+};
+
+IconLabel.propTypes = {
+	icon: PropTypes.object.isRequired,
+	isChecked: PropTypes.bool.isRequired,
+};
+
 const IconGrid = (props) => {
 	const { icons, selectedIcon, onChange } = props;
 
@@ -116,21 +146,11 @@ const IconGrid = (props) => {
 			{icons.map((icon) => {
 				const isChecked =
 					selectedIcon?.name === icon.name && selectedIcon?.iconSet === icon.iconSet;
-				const Label = memo(() => (
-					<>
-						<StyledIconButton
-							isSelected={isChecked}
-							key={icon.name}
-							name={icon.name}
-							iconSet={icon.iconSet}
-						/>
-						<VisuallyHidden>{icon.label}</VisuallyHidden>
-					</>
-				));
+
 				return (
 					<CheckboxControl
 						key={icon.name}
-						label={<Label />}
+						label={<IconLabel isChecked={isChecked} icon={icon} />}
 						checked={isChecked}
 						onChange={() => onChange(icon)}
 						className="component-icon-picker__checkbox-control"

--- a/components/icon-picker/inline-icon-picker.js
+++ b/components/icon-picker/inline-icon-picker.js
@@ -24,7 +24,7 @@ export const InlineIconPicker = (props) => {
 	const { value, ...rest } = props;
 	const IconButton = useCallback(
 		({ onToggle }) => (
-			<Icon name={value.name} iconSet={value.iconSet} onClick={onToggle} {...rest} />
+			<Icon name={value?.name} iconSet={value?.iconSet} onClick={onToggle} {...rest} />
 		),
 		[value, rest],
 	);

--- a/components/icon-picker/inline-icon-picker.js
+++ b/components/icon-picker/inline-icon-picker.js
@@ -46,7 +46,7 @@ export const IconPickerDropdown = (props) => {
 		<Dropdown
 			className="component-icon-picker-inline-button"
 			contentClassName="component-icon-picker-inline__content"
-			position="bottom right"
+			popoverProps={{ placement: 'bottom-start' }}
 			renderToggle={renderToggle}
 			renderContent={() => <StyledIconPickerDropdown {...iconPickerProps} />}
 		/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@10up/block-components",
-  "version": "1.15.11-alpha.0",
+  "version": "1.15.11-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@10up/block-components",
-      "version": "1.15.11-alpha.0",
+      "version": "1.15.11-alpha.1",
       "license": "GPL-2.0-or-later",
       "workspaces": [
         "./",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@10up/block-components",
-  "version": "1.15.11-alpha.1",
+  "version": "1.15.11-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@10up/block-components",
-      "version": "1.15.11-alpha.1",
+      "version": "1.15.11-alpha.2",
       "license": "GPL-2.0-or-later",
       "workspaces": [
         "./",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@10up/block-components",
-  "version": "1.15.10",
+  "version": "1.15.11-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@10up/block-components",
-      "version": "1.15.10",
+      "version": "1.15.11-alpha.0",
       "license": "GPL-2.0-or-later",
       "workspaces": [
         "./",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.15.11-alpha.0",
+  "version": "1.15.11-alpha.1",
   "description": "10up Components built for the WordPress Block Editor.",
   "main": "./dist/index.js",
   "source": "index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.15.10",
+  "version": "1.15.11-alpha.0",
   "description": "10up Components built for the WordPress Block Editor.",
   "main": "./dist/index.js",
   "source": "index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.15.11-alpha.1",
+  "version": "1.15.11-alpha.2",
   "description": "10up Components built for the WordPress Block Editor.",
   "main": "./dist/index.js",
   "source": "index.js",


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Fix how the IconGrid gets rendered inside the Icon Picker in order to prevent unwanted rerenders of the component. This should fix the issue described in #229. Whilst working in the codebase I also updated the usage of the deprecated `placement` prop of the Dropdown component (#226).

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #226, #229 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Open the IconPicker 
2. Change the selected icon / type in the search bar

Expected Result:
The icons should not revert to a Spinner state when the state changes. Also, the browser console should not show any warnings. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Prevent unintentional rerenders of IconGrid inside IconPicker component


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy, @benlk 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
