### PR TITLE
Search content when at least 3 letters typed in ContentSearch component

### DIFF
--- a/components/content-search/index.js
+++ b/components/content-search/index.js
@@ -14,17 +14,17 @@ const NAMESPACE = 'tenup-content-search';
 const listMinHeight = '46px';
 
 const ContentSearch = ({
-	onSelectItem,
-	placeholder,
-	label,
-	contentTypes,
-	mode,
-	perPage,
-	queryFilter,
-	excludeItems,
-	renderItemType,
-	fetchInitialResults,
-}) => {
+						   onSelectItem,
+						   placeholder,
+						   label,
+						   contentTypes,
+						   mode,
+						   perPage,
+						   queryFilter,
+						   excludeItems,
+						   renderItemType,
+						   fetchInitialResults,
+					   }) => {
 	const [searchString, setSearchString] = useState('');
 	const [searchQueries, setSearchQueries] = useState({});
 	const [selectedItem, setSelectedItem] = useState(null);
@@ -147,32 +147,35 @@ const ContentSearch = ({
 			setCurrentPage(1);
 		}
 
-		const preparedQuery = prepareSearchQuery(keyword, page);
+		// Let's search the content when at least 3 letters typed.
+		if (keyword.length >= 3) {
+			const preparedQuery = prepareSearchQuery(keyword, page);
 
-		// Only do query if not cached or previously errored/cancelled
-		if (!searchQueries[preparedQuery] || searchQueries[preparedQuery].controller === 1) {
-			setSearchQueries((queries) => {
-				const newQueries = {};
+			// Only do query if not cached or previously errored/cancelled
+			if (!searchQueries[preparedQuery] || searchQueries[preparedQuery].controller === 1) {
+				setSearchQueries((queries) => {
+					const newQueries = {};
 
-				// Remove errored or cancelled queries
-				Object.keys(queries).forEach((query) => {
-					if (queries[query].controller !== 1) {
-						newQueries[query] = queries[query];
-					}
+					// Remove errored or cancelled queries
+					Object.keys(queries).forEach((query) => {
+						if (queries[query].controller !== 1) {
+							newQueries[query] = queries[query];
+						}
+					});
+
+					newQueries[preparedQuery] = {
+						results: null,
+						controller: null,
+						currentPage: page,
+						totalPages: null,
+					};
+
+					return newQueries;
 				});
+			}
 
-				newQueries[preparedQuery] = {
-					results: null,
-					controller: null,
-					currentPage: page,
-					totalPages: null,
-				};
-
-				return newQueries;
-			});
+			setCurrentPage(page);
 		}
-
-		setCurrentPage(page);
 
 		setSearchString(keyword);
 	};

--- a/components/content-search/index.js
+++ b/components/content-search/index.js
@@ -14,17 +14,17 @@ const NAMESPACE = 'tenup-content-search';
 const listMinHeight = '46px';
 
 const ContentSearch = ({
-						   onSelectItem,
-						   placeholder,
-						   label,
-						   contentTypes,
-						   mode,
-						   perPage,
-						   queryFilter,
-						   excludeItems,
-						   renderItemType,
-						   fetchInitialResults,
-					   }) => {
+	onSelectItem,
+	placeholder,
+	label,
+	contentTypes,
+	mode,
+	perPage,
+	queryFilter,
+	excludeItems,
+	renderItemType,
+	fetchInitialResults,
+}) => {
 	const [searchString, setSearchString] = useState('');
 	const [searchQueries, setSearchQueries] = useState({});
 	const [selectedItem, setSelectedItem] = useState(null);


### PR DESCRIPTION
### Description of the Change
Adds functionality to search the content when at least three letters are typed in the ContentSearch's component search functionality, so we can save network bandwidth.

### How to test the Change
- Add the "Post Searcher" component to the page.
- Type just one letter the REST API is firing, so it is good practice to fire a REST request when at least three letters are added in the search.

### Changelog Entry
> Added - Add functionality to search the content when at least three letters are typed in the ContentSearch's search component.

### Credits
Props @vishalkakadiya 
