### PR TITLE
fix add check before trying to access yoast data store

### DIFF
--- a/hooks/use-primary-term/index.js
+++ b/hooks/use-primary-term/index.js
@@ -35,6 +35,14 @@ export const usePrimaryTerm = (taxonomyName) => {
 				return null;
 			}
 
+			const yoastStore = select('yoast-seo/editor');
+
+			if (!yoastStore) {
+				// eslint-disable-next-line no-console
+				console.error(`The yoast-seo/editor store does is not available.`);
+				return null;
+			}
+
 			return select('yoast-seo/editor').getPrimaryTaxonomyId(taxonomyName);
 		},
 		[


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Currently, the Yoast SEO plugin does not expose their data store in the site editor. (See https://github.com/Yoast/wordpress-seo/issues/20473) Therefore the `usePrimaryTerm` hook currently produces a JS error when called in that context since all the other checks are passing. (The plugin is active and the taxonomy is supported). This adds a simple check for the existence of the data store before trying to call the selector. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->


> Fixed - Add check before trying to access yoast-seo/editor data store



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy

