### PR TITLE
New component: FieldValidation

### DIFF
--- a/components/field-validation/index.js
+++ b/components/field-validation/index.js
@@ -22,7 +22,8 @@ const createTestsArray = (required, validate) => {
 
 	if (required) {
 		const fn = (str) => typeof str === 'string' && str !== '';
-		const res = typeof required === 'string' ? required : __('Required', '10up-block-components');
+		const res =
+			typeof required === 'string' ? required : __('Required', '10up-block-components');
 		tests.push([fn, res]);
 	}
 
@@ -88,9 +89,16 @@ const Error = forwardRef((props, ref) => {
 	const { responses } = props;
 
 	return (
-		<ErrorResponse className="tenup--block-components__validation-error__response" {...props} ref={ref}>
+		<ErrorResponse
+			className="tenup--block-components__validation-error__response"
+			{...props}
+			ref={ref}
+		>
 			{responses.map((response) => (
-				<div key={uuid()} className="tenup--block-components__validation-error__response-rule">
+				<div
+					key={uuid()}
+					className="tenup--block-components__validation-error__response-rule"
+				>
 					{response}
 				</div>
 			))}
@@ -156,14 +164,15 @@ const FieldValidation = (props) => {
 		dispatchLock(responses.length > 0);
 	}, [responses, dispatchLock]);
 
-	const fieldErorrClassName = responses.length > 0 ? 'tenup--block-components__validation-error__field' : '';
+	const fieldErrorClassName =
+		responses.length > 0 ? 'tenup--block-components__validation-error__field' : '';
 
 	return (
 		<>
 			{cloneElement(children, {
 				ref: reference,
 				...children.props,
-				className: classnames(children.props?.className, fieldErorrClassName),
+				className: classnames(children.props?.className, fieldErrorClassName),
 			})}
 
 			{responses.length > 0 && (

--- a/components/field-validation/index.js
+++ b/components/field-validation/index.js
@@ -1,0 +1,189 @@
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect, useMemo, forwardRef, cloneElement } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
+import { useFloating, autoUpdate } from '@floating-ui/react-dom';
+import { v4 as uuid } from 'uuid';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+/**
+ * Create Tests Array
+ *
+ * @description create a sanitized tests array.
+ *
+ * @param {boolean|string} required Field validation required prop.
+ * @param {boolean|Array} validate Field validation validate prop.
+ *
+ * @returns {Array}
+ */
+const createTestsArray = (required, validate) => {
+	const tests = [];
+
+	if (required) {
+		const fn = (str) => typeof str === 'string' && str !== '';
+		const res = typeof required === 'string' ? required : __('Required', '10up-block-library');
+		tests.push([fn, res]);
+	}
+
+	if (validate && Array.isArray(validate)) {
+		const isNested = (arr) => Array.isArray(arr) && arr.some((item) => Array.isArray(item));
+		const sanitized = isNested(validate) ? validate : [validate];
+		sanitized.map((entry) => tests.push(entry));
+	}
+
+	return tests;
+};
+
+/**
+ * Validate Tests Array
+ *
+ * @description test a value against the tests array.
+ *
+ * @param {string} value Field value.
+ * @param {Array} tests Tests array created from required and validate.
+ *
+ * @returns {boolean} responses
+ */
+const validateTestsArray = (value, tests) => {
+	const responses = [];
+
+	tests.forEach((entry) => {
+		if (!Array.isArray(entry)) {
+			return;
+		}
+
+		const [test, res] = entry;
+		const passes = test(value);
+
+		if (passes === false) {
+			responses.push(res);
+		}
+	});
+
+	return responses;
+};
+
+/**
+ * Error Message
+ *
+ * @description style the validation error message.
+ *
+ * @returns <ErrorMessage />
+ */
+const ErrorResponse = styled('div')`
+	--color-warning: #f00;
+
+	color: var(--color-warning);
+`;
+
+/**
+ * Error
+ *
+ * @description display validation error.
+ *
+ * @returns <Error />
+ */
+const Error = forwardRef((props, ref) => {
+	const { responses } = props;
+
+	return (
+		<ErrorResponse className="tenup--block-components__validation-error" {...props} ref={ref}>
+			{responses.map((response) => (
+				<div key={uuid()} className="tenup--block-components__validation-error__rule">
+					{response}
+				</div>
+			))}
+		</ErrorResponse>
+	);
+});
+
+/**
+ * Field Validation
+ *
+ * @description create new component which adds field validation abilities.
+ *
+ * @param {object} props Component props.
+ * @param {string} props.value Field validation value.
+ * @param {boolean|string} props.required Field validation required prop.
+ * @param {boolean|Array} props.validate Field validation validate array prop.
+ * @param {*} props.children Child components.
+ *
+ * @returns {HTMLElement} <FieldValidation />
+ */
+const FieldValidation = (props) => {
+	const { value, required = false, validate = false, children } = props;
+
+	const tests = useMemo(() => createTestsArray(required, validate), [required, validate]);
+
+	const { x, y, reference, floating, strategy } = useFloating({
+		placement: 'bottom-start',
+		strategy: 'fixed',
+		whileElementsMounted: autoUpdate,
+	});
+
+	const [responses, setResponses] = useState(true);
+	const [lockId, setLockId] = useState(null);
+
+	if (lockId === null) {
+		setLockId(uuid());
+	}
+
+	const validateTests = useMemo(
+		() => (value) => {
+			const test = value === '' && required ? [tests[0]] : tests;
+			return validateTestsArray(value, test);
+		},
+		[required, tests],
+	);
+
+	const dispatchLock = useMemo(
+		() => (state) => {
+			if (state) {
+				dispatch('core/editor').lockPostSaving(lockId);
+			} else {
+				dispatch('core/editor').unlockPostSaving(lockId);
+			}
+		},
+		[lockId],
+	);
+
+	useEffect(() => {
+		setResponses(validateTests(value));
+	}, [value, validateTests]);
+
+	useEffect(() => {
+		dispatchLock(responses.length > 0);
+	}, [responses, dispatchLock]);
+
+	return (
+		<>
+			{cloneElement(children, { ref: reference, ...children.props })}
+
+			{responses.length > 0 && (
+				<Error
+					ref={floating}
+					responses={responses}
+					style={{
+						position: strategy,
+						top: y ?? 0,
+						left: x ?? 0,
+					}}
+				/>
+			)}
+		</>
+	);
+};
+
+export { FieldValidation };
+
+FieldValidation.defaultProps = {
+	required: false,
+	validate: false,
+};
+
+FieldValidation.propTypes = {
+	value: PropTypes.string.isRequired,
+	required: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+	validate: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
+	children: PropTypes.node.isRequired,
+};

--- a/components/field-validation/index.js
+++ b/components/field-validation/index.js
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { Global, css } from '@emotion/react';
 
 /**
  * Create Tests Array
@@ -73,9 +74,11 @@ const validateTestsArray = (value, tests) => {
  * @returns <ErrorMessage />
  */
 const ErrorResponse = styled('div')`
-	--color-warning: #f00;
-
-	color: var(--color-warning);
+	color: var(--wp--preset--color--vivid-red);
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+		Helvetica Neue, sans-serif;
+	font-size: 13px;
+	font-weight: 500;
 `;
 
 /**
@@ -166,14 +169,26 @@ const FieldValidation = (props) => {
 
 	const fieldErrorClassName =
 		responses.length > 0 ? 'tenup--block-components__validation-error__field' : '';
+	const mergedClassName = classnames(children.props?.className, fieldErrorClassName);
+
+	const clonedChildren = cloneElement(children, {
+		ref: reference,
+		...children.props,
+		className: mergedClassName,
+	});
 
 	return (
 		<>
-			{cloneElement(children, {
-				ref: reference,
-				...children.props,
-				className: classnames(children.props?.className, fieldErrorClassName),
-			})}
+			<Global
+				styles={css`
+					.tenup--block-components__validation-error__field {
+						/* based on --wp--preset--color--vivid-red: #cf2e2e; */
+						background-color: rgba(207, 46, 46, 0.75);
+					}
+				`}
+			/>
+
+			{clonedChildren}
 
 			{responses.length > 0 && (
 				<Error

--- a/components/field-validation/index.js
+++ b/components/field-validation/index.js
@@ -3,6 +3,7 @@ import { useState, useEffect, useMemo, forwardRef, cloneElement } from '@wordpre
 import { dispatch } from '@wordpress/data';
 import { useFloating, autoUpdate } from '@floating-ui/react-dom';
 import { v4 as uuid } from 'uuid';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
@@ -21,7 +22,7 @@ const createTestsArray = (required, validate) => {
 
 	if (required) {
 		const fn = (str) => typeof str === 'string' && str !== '';
-		const res = typeof required === 'string' ? required : __('Required', '10up-block-library');
+		const res = typeof required === 'string' ? required : __('Required', '10up-block-components');
 		tests.push([fn, res]);
 	}
 
@@ -87,9 +88,9 @@ const Error = forwardRef((props, ref) => {
 	const { responses } = props;
 
 	return (
-		<ErrorResponse className="tenup--block-components__validation-error" {...props} ref={ref}>
+		<ErrorResponse className="tenup--block-components__validation-error__response" {...props} ref={ref}>
 			{responses.map((response) => (
-				<div key={uuid()} className="tenup--block-components__validation-error__rule">
+				<div key={uuid()} className="tenup--block-components__validation-error__response-rule">
 					{response}
 				</div>
 			))}
@@ -155,9 +156,15 @@ const FieldValidation = (props) => {
 		dispatchLock(responses.length > 0);
 	}, [responses, dispatchLock]);
 
+	const fieldErorrClassName = responses.length > 0 ? 'tenup--block-components__validation-error__field' : '';
+
 	return (
 		<>
-			{cloneElement(children, { ref: reference, ...children.props })}
+			{cloneElement(children, {
+				ref: reference,
+				...children.props,
+				className: classnames(children.props?.className, fieldErorrClassName),
+			})}
 
 			{responses.length > 0 && (
 				<Error

--- a/components/field-validation/readme.md
+++ b/components/field-validation/readme.md
@@ -1,0 +1,106 @@
+# Field Validation
+
+The Field Validation component enables the ability to add field validation.
+
+## Usage
+
+### Prop: Required
+
+`<FieldValidation>` provides a `required` prop which accepts true or a string. Passing true will display the default "Required" message, while passing a string enables the use of a custom message.
+
+```js
+import { FieldValidation } from '@10up/block-components';
+
+function BlockEdit(props) {
+    const { attributes, setAttributes } = props;
+    const { title } = attributes;
+
+    return (
+        <>
+            <FieldValidation value={title} required={true}>
+                <RichText
+                    tagName="p"
+                    value={title}
+                    onChange={(value) => setAttributes({ title: value })}
+                />
+            </FieldValidation>
+
+            <FieldValidation value={title} required={__('Title is a required field', '10up')__}>
+                <RichText
+                    tagName="p"
+                    value={title}
+                    onChange={(value) => setAttributes({ title: value })}
+                />
+            </FieldValidation>
+        </>
+    )
+}
+```
+
+### Prop: Validate
+
+`<FieldValidation>` can provide more extensive validation tests, `validate` accepts an array of tests. Each test entry is an array containing a callback function and messaging.
+
+```js
+import { FieldValidation } from '@10up/block-components';
+
+function BlockEdit(props) {
+    const { attributes, setAttributes } = props;
+    const { title } = attributes;
+
+    return (
+        <>
+            <FieldValidation
+                value={title}
+                validate={[ (value) => /^[a-zA-Z\s]+$/.test(value), __('Title requires a-z characters', '10up') ]}
+            >
+                <RichText
+                    tagName="p"
+                    value={title}
+                    onChange={(value) => setAttributes({ title: value })}
+                />
+            </FieldValidation>
+        </>
+    )
+}
+```
+
+### Full example
+
+Required and validate props can be combined. The required validation will display if the value is empty, and validate will display if there is a value.
+
+```js
+import { FieldValidation } from '@10up/block-components';
+
+function BlockEdit(props) {
+    const { attributes, setAttributes } = props;
+    const { title } = attributes;
+
+    return (
+        <>
+            <FieldValidation
+                value={title}
+                required={__('Title is a required field', '10up-block-library')}
+                validate={[
+                    [ (value) => /^[a-zA-Z\s]+$/.test(value), __('Title requires a-z characters', '10up') ],
+                    [ (value) => /^.{10,}$/.test(value), __('Title requires 10 characters or more', '10up') ],
+                ]}
+            >
+                    <RichText
+                        tagName="p"
+                        value={title}
+                        onChange={(value) => setAttributes({ title: value })}
+                    />
+            </FieldValidation>
+        </>
+    )
+}
+```
+
+## Props
+
+| Name       | Type              | Default  |  Description                                                   |
+| ---------- | ----------------- | -------- | -------------------------------------------------------------- |
+| `value` | `string` | `undefined` | Value to validate |
+| `required` | `boolean/string` | `Required` | Required validation message |
+| `validate` | `array` | `[]` | Tests to validate value |

--- a/components/field-validation/readme.md
+++ b/components/field-validation/readme.md
@@ -6,7 +6,7 @@ The Field Validation component enables the ability to add field validation.
 
 ### Prop: Required
 
-`<FieldValidation>` provides a `required` prop which accepts true or a string. Passing true will display the default "Required" message, while passing a string enables the use of a custom message.
+`<FieldValidation>` provides a `required` prop which accepts true or a string. Passing true will display the default response which is "Required", while passing a string enables the use of a custom response.
 
 ```js
 import { FieldValidation } from '@10up/block-components';
@@ -39,7 +39,7 @@ function BlockEdit(props) {
 
 ### Prop: Validate
 
-`<FieldValidation>` can provide more extensive validation tests, `validate` accepts an array of tests. Each test entry is an array containing a callback function and messaging.
+`<FieldValidation>` can provide more extensive validation tests, `validate` accepts an array of tests. Each test entry is an array containing a callback function and response.
 
 ```js
 import { FieldValidation } from '@10up/block-components';
@@ -102,5 +102,5 @@ function BlockEdit(props) {
 | Name       | Type              | Default  |  Description                                                   |
 | ---------- | ----------------- | -------- | -------------------------------------------------------------- |
 | `value` | `string` | `undefined` | Value to validate |
-| `required` | `boolean/string` | `Required` | Required validation message |
+| `required` | `boolean/string` | `Required` | Required validation response |
 | `validate` | `array` | `[]` | Tests to validate value |

--- a/components/field-validation/readme.md
+++ b/components/field-validation/readme.md
@@ -102,5 +102,5 @@ function BlockEdit(props) {
 | Name       | Type              | Default  |  Description                                                   |
 | ---------- | ----------------- | -------- | -------------------------------------------------------------- |
 | `value` | `string` | `undefined` | Value to validate |
-| `required` | `boolean/string` | `Required` | Required validation response |
-| `validate` | `array` | `[]` | Tests to validate value |
+| `required` | `boolean/string` | `false/Required` | Required validation response |
+| `validate` | `array` | `false` | Tests to validate value |

--- a/components/field-validation/readme.md
+++ b/components/field-validation/readme.md
@@ -97,6 +97,17 @@ function BlockEdit(props) {
 }
 ```
 
+## Styling
+
+The following elements/states are available for styling;
+
+- `.tenup--block-components__validation-error__field`
+  - State/class applied to the field when there is a validation error.
+- `.tenup--block-components__validation-error__response`
+  - The responses container element.
+- `.tenup--block-components__validation-error__response-rule`
+  - Each response rule element within the responses container.
+
 ## Props
 
 | Name       | Type              | Default  |  Description                                                   |

--- a/components/field-validation/readme.md
+++ b/components/field-validation/readme.md
@@ -67,7 +67,7 @@ function BlockEdit(props) {
 
 ### Full example
 
-Required and validate props can be combined. The required validation will display if the value is empty, and validate will display if there is a value.
+Required and validate props can be combined. The required validation will display if the value is empty, and validate will display if there is a value available for custom tests.
 
 ```js
 import { FieldValidation } from '@10up/block-components';
@@ -80,7 +80,7 @@ function BlockEdit(props) {
         <>
             <FieldValidation
                 value={title}
-                required={__('Title is a required field', '10up-block-library')}
+                required={__('Title is a required field', '10up')}
                 validate={[
                     [ (value) => /^[a-zA-Z\s]+$/.test(value), __('Title requires a-z characters', '10up') ],
                     [ (value) => /^.{10,}$/.test(value), __('Title requires 10 characters or more', '10up') ],


### PR DESCRIPTION
### Description

This PR creates a new `<FieldValidation>` component that can be used for required fields or fields that require custom tests for validation.

- Fields can be marked as required.
- Fields can have custom validation tests and responses.
- Editor "update" button is disabled if any field validation is failing on the post or page.

Screenshare with failing field validations;

https://github.com/10up/block-components/assets/15921694/18e43322-2236-46a6-abbd-fad0280a48cc

### Testing

Import `<FieldValidation>` and test with the following;

```js
import { FieldValidation } from '@10up/block-components';

function BlockEdit(props) {
    const { attributes, setAttributes } = props;
    const { title } = attributes;

    return (
        <>
            <FieldValidation
                value={title}
                required={__('Title is a required field', '10up')}
                validate={[
                    [ (value) => /^[a-zA-Z\s]+$/.test(value), __('Title requires alphabetical characters', '10up') ],
                    [ (value) => /^.{10,}$/.test(value), __('Title requires 10 characters or more', '10up') ],
                ]}
            >
                    <RichText
                        tagName="p"
                        value={title}
                        onChange={(value) => setAttributes({ title: value })}
                    />
            </FieldValidation>
        </>
    )
}
```

**Known issue:** `<RichTextCharacterLimit>` also uses floating-ui and seems to impact the ref used by `<FieldValidation>` when nested, impacting the position of validation responses. Solution requires further investigation.

### Changelog
- Added - Field Validation component

### Credits
n/a

### Checklist
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
