### PR TITLE
fix add context view to rest request so that authors can view terms

### DIFF
--- a/hooks/use-all-terms/index.js
+++ b/hooks/use-all-terms/index.js
@@ -11,6 +11,7 @@ export const useAllTerms = (taxonomyName) => {
 				taxonomyName,
 				{
 					per_page: -1,
+					context: 'view',
 				},
 			];
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Whilst testing the PostTermList component on a site we found an issue where the block crashed for anyone with the Author user role. Traking it down, the issue is that authors are not able to access the edit context of rest API requests to the taxonomy endpoint. To fix it we explicitly set the context in the `useAllTerms` hook to `view`

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Create a user with the "Author" role
2. Create a new post as the Author
3. Insert the "Hero" block bundled with the example plugin
4. See that the block fails. Test again with this patch applied and see that it is ressolved

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Change context of rest query in `useAllTerms` hook to `view` to ensure users with the role Author can use the component.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dborgesmj @RobertWise  @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
