### PR TITLE
Fix default value of `renderItemType` in `ContentSearch` component 

### DIFF
--- a/components/content-search/SearchItem.js
+++ b/components/content-search/SearchItem.js
@@ -91,14 +91,16 @@ const SearchItem = ({
 	);
 };
 
+export function defaultRenderItemType(suggestion) {
+	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
+	return suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
+}
+
 SearchItem.defaultProps = {
 	id: '',
 	searchTerm: '',
 	isSelected: false,
-	renderType: (suggestion) => {
-		// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
-		return suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
-	},
+	renderType: defaultRenderItemType,
 };
 
 SearchItem.propTypes = {

--- a/components/content-search/index.js
+++ b/components/content-search/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line no-unused-vars
 import { jsx, css } from '@emotion/react';
-import SearchItem from './SearchItem';
+import SearchItem, { defaultRenderItemType } from './SearchItem';
 /** @jsx jsx */
 
 const NAMESPACE = 'tenup-content-search';
@@ -441,10 +441,7 @@ ContentSearch.defaultProps = {
 	onSelectItem: () => {
 		console.log('Select!'); // eslint-disable-line no-console
 	},
-	renderItemType: (suggestion) => {
-		// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
-		return suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
-	},
+	renderItemType: defaultRenderItemType,
 	fetchInitialResults: false,
 };
 

--- a/components/content-search/index.js
+++ b/components/content-search/index.js
@@ -441,7 +441,10 @@ ContentSearch.defaultProps = {
 	onSelectItem: () => {
 		console.log('Select!'); // eslint-disable-line no-console
 	},
-	renderItemType: undefined,
+	renderItemType: (suggestion) => {
+		// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
+		return suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
+	},
 	fetchInitialResults: false,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@10up/block-components",
-  "version": "1.16.1",
+  "version": "1.16.2-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@10up/block-components",
-      "version": "1.16.1",
+      "version": "1.16.2-alpha.0",
       "license": "GPL-2.0-or-later",
       "workspaces": [
         "./",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.16.1",
+  "version": "1.16.2-alpha.0",
   "description": "10up Components built for the WordPress Block Editor.",
   "main": "./dist/index.js",
   "source": "index.js",


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

When the content search component gets multiple content types passed in, it also accepts a `renderItemType` prop that allows developers to manipulate the "Type" label at the end of each suggestion. The issue is, that the default value for the `renderItemType` function was set to `undefined` therefore overwriting the default value of the `renderType` function in the subcomponent where it gets consumed. 

This fix now applies the same default value in both places to ensure it doesn't get overwritten


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Create a block that uses the `ContentSearch` or `ContentPicker` component with multiple `contentTypes`
```js
<ContentPicker
	contentTypes={['post', 'page']}
/>
```
2. See that it causes an error when the content picker attempts to show search results

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - default value of `renderItemType` in `ContentSearch` component 



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @cameronterry @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
