### PR TITLE
Fix Icon Picker rendering empty when one item should be rendered

### DIFF
--- a/components/icon-picker/icon-picker.js
+++ b/components/icon-picker/icon-picker.js
@@ -153,7 +153,7 @@ IconLabel.propTypes = {
 const IconGridItem = memo((props) => {
 	const { columnIndex, rowIndex, style, data } = props;
 	const { icons, selectedIcon, onChange } = data;
-	const index = rowIndex * 5 + columnIndex + 1;
+	const index = rowIndex * 5 + columnIndex;
 	const icon = icons[index];
 	const isChecked = selectedIcon?.name === icon?.name && selectedIcon?.iconSet === icon?.iconSet;
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

The code to retrieve the icon to be rendered in the icon grid had a logical error in it. When it tried to calculate the index of the icon to render based on the position of the icon in the virtualized grid, the maths was adding +1 at the end to make its index human-readable instead of index 0 which we would need to actually render the correct icon. 

This issue means that regardless of the state of the icon picker, the first icon in the list is not rendered. This becomes most obvious when there only is one icon like when you are searching and there is only one match.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #248 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Insert Icon Picker
2. Search for an icon name that only occurs once. / Alternatively only register one singular icon

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Empty rendering of first item in Icon Picker due to index 0


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @psorensen @TylerB24890 @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
