### PR TITLE
Add action to automate release

### DIFF
--- a/.github/workflows/release-npm-version.yml
+++ b/.github/workflows/release-npm-version.yml
@@ -11,6 +11,14 @@ on:
         - patch
         - minor
         - major
+      dry_run:
+        description: 'Dry Run'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+        - true
+        - false
 concurrency: 
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -33,8 +41,8 @@ jobs:
 
       - name: npm update version and release
         run: |
-          npm version ${{ github.event.inputs.release_type }}
-          npm publish
+          npm version ${{ github.event.inputs.release_type }} git-tag-version=${{ github.event.inputs.dry_run == 'false' }}
+          npm publish --dry-run=${{ github.event.inputs.dry_run }}
         env:
            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       

--- a/.github/workflows/release-npm-version.yml
+++ b/.github/workflows/release-npm-version.yml
@@ -1,0 +1,42 @@
+name: Publish new version to NPM
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release Type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
+concurrency: 
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  build_and_release:
+    environment: production
+    if: github.ref == 'refs/heads/trunk'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Configure git user name and email
+        run: |
+            git config user.name "10up Bot"
+            git config user.email "pr@10up.com"
+
+      - name: npm update version and release
+        run: |
+          npm version ${{ github.event.inputs.release_type }}
+          npm publish
+        env:
+           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      - name: push release commit to repo
+        run: git push

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@10up/block-components",
-  "version": "1.16.2",
+  "version": "1.16.3-testing-release.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@10up/block-components",
-      "version": "1.16.2",
+      "version": "1.16.3-testing-release.0",
       "license": "GPL-2.0-or-later",
       "workspaces": [
         "./",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-test-env": "npm run build --workspaces --if-present",
     "start-test-env": "npm run start-env -w example/ && npm run import-media -w example/",
     "test:e2e": "cypress open",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm ci && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.16.2",
+  "version": "1.16.3-testing-release.0",
   "description": "10up Components built for the WordPress Block Editor.",
   "main": "./dist/index.js",
   "source": "index.js",


### PR DESCRIPTION
This action allows maintainers to trigger a new release via the UI in GitHub and therefore standardizes the release process.