### PR TITLE
Fix JSX nesting error in example

### DIFF
--- a/components/repeater/readme.md
+++ b/components/repeater/readme.md
@@ -21,8 +21,10 @@ export function BlockEdit(props) {
     return (
         <Repeater attribute="items">
             {( item, index, setItem, removeItem ) => (
-                <TextControl key={index} value={item} onChange={(value) => setItem(value)} />
-                <Button icon={close} label={__('Remove')} onClick={removeItem}/>
+                <>
+                    <TextControl key={index} value={item} onChange={(value) => setItem(value)} />
+                    <Button icon={close} label={__('Remove')} onClick={removeItem}/>
+                </>
             )}
         </Repeater>
     );


### PR DESCRIPTION
The nesting in the JSX in the README example is invalid. The TextControl and Button components need to be wrapped in a containing element.