### PR TITLE
Refactor `Repeater` component to also work for non attribute data storage

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -8,7 +8,7 @@ export { ContentPicker } from './content-picker';
 export { DragHandle } from './drag-handle';
 export { ColorSetting } from './color-settings';
 export { ClipboardButton } from './clipboard-button';
-export { Repeater } from './repeater';
+export { Repeater as AbstractRepeater, AttributeRepeater as Repeater } from './repeater';
 export { Link } from './link';
 export { MediaToolbar } from './media-toolbar';
 export { Image } from './image';

--- a/components/index.js
+++ b/components/index.js
@@ -8,7 +8,7 @@ export { ContentPicker } from './content-picker';
 export { DragHandle } from './drag-handle';
 export { ColorSetting } from './color-settings';
 export { ClipboardButton } from './clipboard-button';
-export { Repeater as AbstractRepeater, AttributeRepeater as Repeater } from './repeater';
+export { Repeater } from './repeater';
 export { Link } from './link';
 export { MediaToolbar } from './media-toolbar';
 export { Image } from './image';

--- a/components/repeater/index.js
+++ b/components/repeater/index.js
@@ -293,13 +293,14 @@ Repeater.propTypes = {
 	allowReordering: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	value: PropTypes.array.isRequired,
-	defaultValue: PropTypes.array.isRequired,
+	defaultValue: PropTypes.array,
 };
 
 Repeater.defaultProps = {
-	attribute: 'items',
+	attribute: null,
 	addButton: null,
 	allowReordering: false,
+	defaultValue: [],
 };
 
 AttributeRepeater.propTypes = {
@@ -310,7 +311,7 @@ AttributeRepeater.propTypes = {
 };
 
 AttributeRepeater.defaultProps = {
-	attribute: 'items',
+	attribute: null,
 	addButton: null,
 	allowReordering: false,
 };
@@ -321,12 +322,13 @@ AbstractRepeater.propTypes = {
 	allowReordering: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	value: PropTypes.array.isRequired,
-	defaultValue: PropTypes.array.isRequired,
+	defaultValue: PropTypes.array,
 };
 
 AbstractRepeater.defaultProps = {
 	addButton: null,
 	allowReordering: false,
+	defaultValue: [],
 };
 
 SortableItem.defaultProps = {

--- a/components/repeater/index.js
+++ b/components/repeater/index.js
@@ -26,41 +26,65 @@ import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import { CSS } from '@dnd-kit/utilities';
 import { DragHandle } from '../drag-handle';
 
+export const AttributeRepeater = ({ children, attribute, addButton, allowReordering }) => {
+	const { clientId, name } = useBlockEditContext();
+	const { updateBlockAttributes } = dispatch(blockEditorStore);
+
+	const attributeValue = useSelect((select) => {
+		const attributes = select(blockEditorStore).getBlockAttributes(clientId);
+		return attributes[attribute] || [];
+	});
+
+	const { defaultRepeaterData } = useSelect((select) => {
+		return {
+			defaultRepeaterData:
+				select(blocksStore).getBlockType(name).attributes[attribute].default,
+		};
+	});
+
+	const handleOnChange = (value) => {
+		updateBlockAttributes(clientId, { [attribute]: value });
+	};
+
+	return (
+		<Repeater
+			addButton={addButton}
+			allowReordering={allowReordering}
+			onChange={handleOnChange}
+			value={attributeValue}
+			defaultValue={defaultRepeaterData}
+		>
+			{children}
+		</Repeater>
+	);
+};
+
 /**
  * The Repeater Component.
  *
  * @param {object} props React props
  * @param {Function} props.children Render prop to render the children.
- * @param {string} props.attribute property of the block attribute that will provide data for Repeater.
  * @param {string} props.addButton render prop to customize the "Add item" button.
  * @param {boolean} props.allowReordering boolean to toggle reordering of Repeater items.
+ * @param {Function} props.onChange callback function to update the block attribute.
+ * @param {Array} props.value array of Repeater items.
+ * @param {Array} props.defaultValue array of default Repeater items.
  * @returns {*} React JSX
  */
-export const Repeater = ({ children, attribute, addButton, allowReordering }) => {
-	const { clientId, name } = useBlockEditContext();
-	const { updateBlockAttributes } = dispatch(blockEditorStore);
-
+export const Repeater = ({
+	children,
+	addButton,
+	allowReordering,
+	onChange,
+	value,
+	defaultValue,
+}) => {
 	const sensors = useSensors(
 		useSensor(PointerSensor),
 		useSensor(KeyboardSensor, {
 			coordinateGetter: sortableKeyboardCoordinates,
 		}),
 	);
-
-	const { repeaterData, defaultRepeaterData } = useSelect((select) => {
-		const { getBlockAttributes } = select(blockEditorStore);
-		const { getBlockType } = select(blocksStore);
-		const repeaterDataTemp = getBlockAttributes(clientId)[attribute];
-
-		if (repeaterDataTemp.length === 1 && !repeaterDataTemp[0].id) {
-			repeaterDataTemp[0].id = uuid();
-		}
-
-		return {
-			repeaterData: repeaterDataTemp,
-			defaultRepeaterData: getBlockType(name).attributes[attribute].default,
-		};
-	});
 
 	function handleDragEnd(event) {
 		const { active, over } = event;
@@ -73,9 +97,7 @@ export const Repeater = ({ children, attribute, addButton, allowReordering }) =>
 				return arrayMove(items, oldIndex, newIndex);
 			};
 
-			updateBlockAttributes(clientId, {
-				[attribute]: moveArray(repeaterData),
-			});
+			onChange(moveArray(value));
 		}
 	}
 
@@ -84,41 +106,40 @@ export const Repeater = ({ children, attribute, addButton, allowReordering }) =>
 	 */
 	function addItem() {
 		/*
-		 * [...defaultRepeaterData] does a shallow copy. To ensure deep-copy,
+		 * [...defaultValue] does a shallow copy. To ensure deep-copy,
 		 * we do JSON.parse(JSON.stringify()).
 		 */
-		const defaultRepeaterDataCopy = JSON.parse(JSON.stringify(defaultRepeaterData));
+		const defaultValueCopy = JSON.parse(JSON.stringify(defaultValue));
 
-		if (!defaultRepeaterData.length) {
-			defaultRepeaterDataCopy.push([]);
+		if (!defaultValue.length) {
+			defaultValueCopy.push([]);
 		}
 
-		defaultRepeaterDataCopy[0].id = uuid();
+		defaultValueCopy[0].id = uuid();
 
-		updateBlockAttributes(clientId, {
-			[attribute]: [...repeaterData, ...defaultRepeaterDataCopy],
-		});
+		onChange([...value, ...defaultValueCopy]);
 	}
 
 	/**
 	 * Updates the item currently being edited.
 	 *
-	 * @param {string|number|boolean} value The value that should be used to updated the item.
+	 * @param {string|number|boolean} newValue The value that should be used to updated the item.
 	 * @param {number} index The index at which the item should be updated.
 	 */
-	function setItem(value, index) {
+	function setItem(newValue, index) {
 		/*
-		 * [...repeaterData] does a shallow copy. To ensure deep-copy,
+		 * [...value] does a shallow copy. To ensure deep-copy,
 		 * we do JSON.parse(JSON.stringify()).
 		 */
-		const repeaterDataCopy = JSON.parse(JSON.stringify(repeaterData));
+		const valueCopy = JSON.parse(JSON.stringify(value));
 
-		if (typeof value === 'object' && value !== null) {
-			repeaterDataCopy[index] = { ...repeaterDataCopy[index], ...value };
+		if (typeof newValue === 'object' && newValue !== null) {
+			valueCopy[index] = { ...valueCopy[index], ...newValue };
 		} else {
-			repeaterDataCopy[index] = value;
+			valueCopy[index] = newValue;
 		}
-		updateBlockAttributes(clientId, { [attribute]: repeaterDataCopy });
+
+		onChange(valueCopy);
 	}
 
 	/**
@@ -127,13 +148,13 @@ export const Repeater = ({ children, attribute, addButton, allowReordering }) =>
 	 * @param {number} index The index of the item that needs to be removed.
 	 */
 	function removeItem(index) {
-		const repeaterDataCopy = JSON.parse(JSON.stringify(repeaterData)).filter(
+		const valueCopy = JSON.parse(JSON.stringify(value)).filter(
 			(item, innerIndex) => index !== innerIndex,
 		);
-		updateBlockAttributes(clientId, { [attribute]: repeaterDataCopy });
+		onChange(valueCopy);
 	}
 
-	const itemIds = repeaterData.map((item) => item.id);
+	const itemIds = value.map((item) => item.id);
 
 	return (
 		<>
@@ -145,7 +166,7 @@ export const Repeater = ({ children, attribute, addButton, allowReordering }) =>
 					modifiers={[restrictToVerticalAxis]}
 				>
 					<SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-						{repeaterData.map((item, key) => {
+						{value.map((item, key) => {
 							return (
 								<SortableItem
 									item={item}
@@ -168,7 +189,7 @@ export const Repeater = ({ children, attribute, addButton, allowReordering }) =>
 					</SortableContext>
 				</DndContext>
 			) : (
-				repeaterData.map((item, key) => {
+				value.map((item, key) => {
 					return children(
 						item,
 						item.id,
@@ -232,16 +253,30 @@ const SortableItem = ({ children, item, setItem, removeItem, id }) => {
 };
 
 Repeater.defaultProps = {
+	addButton: null,
+	allowReordering: false,
+};
+
+AttributeRepeater.defaultProps = {
 	attribute: 'items',
 	addButton: null,
 	allowReordering: false,
 };
 
-Repeater.propTypes = {
+AttributeRepeater.propTypes = {
 	children: PropTypes.func.isRequired,
 	attribute: PropTypes.string,
 	addButton: PropTypes.func,
 	allowReordering: PropTypes.bool,
+};
+
+Repeater.propTypes = {
+	children: PropTypes.func.isRequired,
+	addButton: PropTypes.func,
+	allowReordering: PropTypes.bool,
+	onChange: PropTypes.func.isRequired,
+	value: PropTypes.array.isRequired,
+	defaultValue: PropTypes.array.isRequired,
 };
 
 SortableItem.defaultProps = {

--- a/components/repeater/index.js
+++ b/components/repeater/index.js
@@ -47,7 +47,7 @@ export const AttributeRepeater = ({ children, attribute, addButton, allowReorder
 	};
 
 	return (
-		<Repeater
+		<AbstractRepeater
 			addButton={addButton}
 			allowReordering={allowReordering}
 			onChange={handleOnChange}
@@ -55,7 +55,7 @@ export const AttributeRepeater = ({ children, attribute, addButton, allowReorder
 			defaultValue={defaultRepeaterData}
 		>
 			{children}
-		</Repeater>
+		</AbstractRepeater>
 	);
 };
 
@@ -71,7 +71,7 @@ export const AttributeRepeater = ({ children, attribute, addButton, allowReorder
  * @param {Array} props.defaultValue array of default Repeater items.
  * @returns {*} React JSX
  */
-export const Repeater = ({
+export const AbstractRepeater = ({
 	children,
 	addButton,
 	allowReordering,
@@ -209,6 +209,40 @@ export const Repeater = ({
 	);
 };
 
+export const Repeater = ({
+	children,
+	addButton,
+	allowReordering,
+	onChange,
+	value,
+	defaultValue,
+	attribute,
+}) => {
+	if (attribute) {
+		return (
+			<AttributeRepeater
+				attribute={attribute}
+				addButton={addButton}
+				allowReordering={allowReordering}
+			>
+				{children}
+			</AttributeRepeater>
+		);
+	}
+
+	return (
+		<AbstractRepeater
+			addButton={addButton}
+			allowReordering={allowReordering}
+			onChange={onChange}
+			value={value}
+			defaultValue={defaultValue}
+		>
+			{children}
+		</AbstractRepeater>
+	);
+};
+
 /**
  * The Sortable Item Component.
  *
@@ -252,12 +286,17 @@ const SortableItem = ({ children, item, setItem, removeItem, id }) => {
 	return clonedRepeaterChild;
 };
 
-Repeater.defaultProps = {
-	addButton: null,
-	allowReordering: false,
+Repeater.propTypes = {
+	children: PropTypes.func.isRequired,
+	addButton: PropTypes.func,
+	attribute: PropTypes.string,
+	allowReordering: PropTypes.bool,
+	onChange: PropTypes.func.isRequired,
+	value: PropTypes.array.isRequired,
+	defaultValue: PropTypes.array.isRequired,
 };
 
-AttributeRepeater.defaultProps = {
+Repeater.defaultProps = {
 	attribute: 'items',
 	addButton: null,
 	allowReordering: false,
@@ -270,13 +309,24 @@ AttributeRepeater.propTypes = {
 	allowReordering: PropTypes.bool,
 };
 
-Repeater.propTypes = {
+AttributeRepeater.defaultProps = {
+	attribute: 'items',
+	addButton: null,
+	allowReordering: false,
+};
+
+AbstractRepeater.propTypes = {
 	children: PropTypes.func.isRequired,
 	addButton: PropTypes.func,
 	allowReordering: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 	value: PropTypes.array.isRequired,
 	defaultValue: PropTypes.array.isRequired,
+};
+
+AbstractRepeater.defaultProps = {
+	addButton: null,
+	allowReordering: false,
 };
 
 SortableItem.defaultProps = {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Adds an abstraction of the Attributes repeater that handles the data storage in Attributes. But therefor also allows any other data storage to function.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Ability to use `Repeater` component for non Attributes



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy @gthayer 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
