### PR TITLE
fix styling of content picker component inside iframed editors

### DIFF
--- a/components/content-picker/index.js
+++ b/components/content-picker/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { v4 as uuidv4 } from 'uuid';
 import { ContentSearch } from '../content-search';
 import SortableList from './SortableList';
+import { StyledComponentContext } from '../styled-components-context';
 
 const NAMESPACE = 'tenup-content-picker';
 
@@ -13,7 +14,7 @@ const NAMESPACE = 'tenup-content-picker';
  * Unfortunately, we had to use !important because on PickedItem we couldn't @emotion/styled css
  * as it was breaking sortability from react-sortable-hoc
  */
-const StyleWrapper = styled('div')`
+const StyleWrapper = styled.div`
 	& .block-editor-link-control__search-item {
 		cursor: default;
 
@@ -27,7 +28,7 @@ const StyleWrapper = styled('div')`
  * Without this, the flex parents will limit the width of the picker. Fixes view when the results
  * all have short titles.
  */
-const ContentPickerWrapper = styled('div')`
+const ContentPickerWrapper = styled.div`
 	width: 100%;
 `;
 
@@ -120,55 +121,60 @@ const ContentPicker = ({
 	}, [content, currentPostId, excludeCurrentPost, uniqueContentItems]);
 
 	return (
-		<ContentPickerWrapper className={NAMESPACE}>
-			{!content.length || (content.length && content.length < maxContentItems) ? (
-				<ContentSearch
-					placeholder={placeholder}
-					label={label}
-					excludeItems={excludeItems}
-					onSelectItem={handleSelect}
-					contentTypes={contentTypes}
-					mode={mode}
-					queryFilter={queryFilter}
-					perPage={perPage}
-					fetchInitialResults={fetchInitialResults}
-				/>
-			) : (
-				label && (
-					<div
-						style={{
-							marginBottom: '8px',
-						}}
-					>
-						{label}
-					</div>
-				)
-			)}
+		<StyledComponentContext cacheKey="tenup-component-content-picker">
+			<ContentPickerWrapper className={NAMESPACE}>
+				{!content.length || (content.length && content.length < maxContentItems) ? (
+					<ContentSearch
+						placeholder={placeholder}
+						label={label}
+						excludeItems={excludeItems}
+						onSelectItem={handleSelect}
+						contentTypes={contentTypes}
+						mode={mode}
+						queryFilter={queryFilter}
+						perPage={perPage}
+						fetchInitialResults={fetchInitialResults}
+					/>
+				) : (
+					label && (
+						<div
+							style={{
+								marginBottom: '8px',
+							}}
+						>
+							{label}
+						</div>
+					)
+				)}
 
-			{Boolean(content?.length) && (
-				<StyleWrapper>
-					<span
-						style={{
-							marginTop: '15px',
-							marginBottom: '2px',
-							display: 'block',
-						}}
-					>
-						{content.length > 1 ? multiPickedLabel : singlePickedLabel}
-					</span>
+				{Boolean(content?.length) && (
+					<StyleWrapper>
+						<span
+							style={{
+								marginTop: '15px',
+								marginBottom: '2px',
+								display: 'block',
+							}}
+						>
+							{content.length > 1 ? multiPickedLabel : singlePickedLabel}
+						</span>
 
-					<ul className="block-editor-link-control__search-items">
-						<SortableList
-							posts={content}
-							handleItemDelete={onDeleteItem}
-							isOrderable={isOrderable}
-							mode={mode}
-							setPosts={onPickChange}
-						/>
-					</ul>
-				</StyleWrapper>
-			)}
-		</ContentPickerWrapper>
+						<ul
+							className="block-editor-link-control__search-items"
+							style={{ padding: 0 }}
+						>
+							<SortableList
+								posts={content}
+								handleItemDelete={onDeleteItem}
+								isOrderable={isOrderable}
+								mode={mode}
+								setPosts={onPickChange}
+							/>
+						</ul>
+					</StyleWrapper>
+				)}
+			</ContentPickerWrapper>
+		</StyledComponentContext>
 	);
 };
 

--- a/components/styled-components-context/index.js
+++ b/components/styled-components-context/index.js
@@ -1,0 +1,44 @@
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
+import { useRefEffect, useInstanceId } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+import propTypes from 'prop-types';
+
+export const StyledComponentContext = (props) => {
+	const { children, cacheKey } = props;
+	const fallbackKey = useInstanceId(StyledComponentContext);
+
+	const defaultCache = createCache({
+		key: cacheKey || fallbackKey,
+	});
+
+	const [cache, setCache] = useState(defaultCache);
+	const nodeRef = useRefEffect(
+		(node) => {
+			if (node) {
+				setCache(
+					createCache({
+						key: cacheKey || fallbackKey,
+						container: node,
+					}),
+				);
+			}
+			return () => {
+				setCache(defaultCache);
+			};
+		},
+		[cacheKey, fallbackKey],
+	);
+
+	return (
+		<>
+			<span ref={nodeRef} style={{ display: 'none' }} />
+			<CacheProvider value={cache}>{children}</CacheProvider>
+		</>
+	);
+};
+
+StyledComponentContext.propTypes = {
+	children: propTypes.node.isRequired,
+	cacheKey: propTypes.string.isRequired,
+};


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

The `ContentPicker` & `ContentSearch` components both use emotion styled-components for styling in the editor. Emotion works by dynamically generating custom class names and style tags containing the styles for these classes. 

When the block editors get rendered in the iframed editor the style tags get injected in the main window and therefore have no effect on the content within the iframe. 

The Emotion docs mention that we need to create a new `emotion/cache` and pass it the node which it should reference for injecting the style tags.

Since this will be needed for all our components eventually, I have created a new wrapper component called `StyledComponentContext`, which is private to the block components library (it doesn't get exported). This wrapper handles the creation of this cache and ensures that the component is wrapped in the appropriate provider. 

| Before | After |
|--------|------|
| <img width="500" alt="CleanShot 2023-09-19 at 10 09 45@2x" src="https://github.com/10up/block-components/assets/20684594/73d4dd42-eb43-43e8-b7cd-4ed504a2d0d7"> | <img width="500" alt="CleanShot 2023-09-19 at 10 09 08@2x" src="https://github.com/10up/block-components/assets/20684594/d5cb3ded-b6ca-4d35-bff5-e8dd5d47d582"> |

> **Note**
> This solution is a little hacky because in order to access the actual DOM where the style tags should get injected, we need to add a ref somewhere in the same context as the component we want to render. The way this is done here is by rendering an additional `span` element next to the actual component wrapped in the provider that is set to `display: none;`
> If anyone has a better idea for how achieve this I'm also happy with that :) 


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Open the site editor
- Insert the "Hello World" Sample block
- See whether the component renders as expected

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Rendering of Content Picker / Content Search component in iframed editors


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy @tlovett1 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
