### PR TITLE
Fix: Make `useIsSupportedMetaField` hook context aware

### DIFF
--- a/example/src/blocks/post-meta/block.json
+++ b/example/src/blocks/post-meta/block.json
@@ -9,5 +9,9 @@
 			"default": ""
 		}
 	},
+	"usesContext": [
+		"postId",
+		"postType"
+	],
 	"editorScript": "file:./index.js"
 }

--- a/example/src/blocks/post-meta/edit.js
+++ b/example/src/blocks/post-meta/edit.js
@@ -5,10 +5,11 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { PostMeta } from '@10up/block-components';
+import { PostMeta, PostContext } from '@10up/block-components';
 
 export const BlockEdit = (props) => {
-	const { attributes, setAttributes, name } = props;
+	const { attributes, setAttributes, name, context } = props;
+	const { postId, postType } = context;
 	const { metaKey } = attributes;
 	const blockProps = useBlockProps();
 
@@ -46,7 +47,9 @@ export const BlockEdit = (props) => {
 
 	return (
 		<div {...blockProps}>
-			<PostMeta metaKey={metaKey} placeholder="Meta Value" />
+			<PostContext postId={postId} postType={postType}>
+				<PostMeta metaKey={metaKey} placeholder="Meta Value" />
+			</PostContext>
 		</div>
 	);
 };

--- a/hooks/use-is-supported-meta-value/index.js
+++ b/hooks/use-is-supported-meta-value/index.js
@@ -1,14 +1,11 @@
-import { useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
+import { useEntityRecord } from '@wordpress/core-data';
+import { usePost } from '../use-post';
 
 export const useIsSupportedMetaField = (metaKey) => {
-	return useSelect(
-		(select) => {
-			const meta = select(editorStore).getCurrentPostAttribute('meta');
-			const supportedMetaKeys = Object.keys(meta || {});
-			const isSupportedMetaField = supportedMetaKeys?.some((name) => name === metaKey);
-			return [!!isSupportedMetaField];
-		},
-		[metaKey],
-	);
+	const { postId, postType } = usePost();
+	const { record } = useEntityRecord('postType', postType, postId);
+	const { meta } = record || {};
+	const supportedMetaKeys = Object.keys(meta || {});
+	const isSupportedMetaField = supportedMetaKeys?.some((name) => name === metaKey);
+	return [!!isSupportedMetaField];
 };


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

We currently check whether the currently edited post supports a meta key before actually rendering the content of the post meta component. This however means that it actually is incorrect for any post meta block used within a query or post picker block. 

This PR fixes that and ensures that the check always uses the post based on the available post context.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

 - Place the Post Meta block inside a query block and see that is pulls in the correct info

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->


> Fixed - Make `useIsSupportedMetaField` hook context aware


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
