### PR TITLE
Image component: pass allowedTypes to MediaPlaceholder

### DIFF
--- a/components/image/index.js
+++ b/components/image/index.js
@@ -14,6 +14,7 @@ const Image = (props) => {
 		onChangeFocalPoint,
 		labels = {},
 		canEditImage = true,
+		allowedTypes = ['image'],
 		...rest
 	} = props;
 	const hasImage = !!id;
@@ -27,7 +28,13 @@ const Image = (props) => {
 
 	if (!hasImage && canEditImage) {
 		return (
-			<MediaPlaceholder labels={labels} onSelect={onSelect} accept="image" multiple={false} />
+			<MediaPlaceholder
+				labels={labels}
+				onSelect={onSelect}
+				accept="image"
+				multiple={false}
+				allowedTypes={allowedTypes}
+			/>
 		);
 	}
 
@@ -77,6 +84,7 @@ Image.defaultProps = {
 	onChangeFocalPoint: undefined,
 	labels: {},
 	canEditImage: true,
+	allowedTypes: ['image'],
 };
 
 Image.propTypes = {
@@ -84,6 +92,7 @@ Image.propTypes = {
 	size: PropTypes.string,
 	onSelect: PropTypes.func.isRequired,
 	onChangeFocalPoint: PropTypes.func,
+	allowedTypes: PropTypes.array,
 	focalPoint: PropTypes.shape({
 		x: PropTypes.string,
 		y: PropTypes.string,

--- a/components/image/readme.md
+++ b/components/image/readme.md
@@ -29,9 +29,10 @@ function BlockEdit(props) {
             onSelect={handleImageSelect}
             focalPoint={focalPoint}
             onChangeFocalPoint={handleFocalPointChange}
+            allowedTypes={['image/gif']}
             labels={{
-                title: 'Select Poster Image',
-                instructions: 'Upload a media file or pick one from your media library.'
+                title: 'Select Gif Image',
+                instructions: 'Upload a GIF or pick one from your media library.'
             }}
         />
     )
@@ -52,4 +53,5 @@ function BlockEdit(props) {
 | `onChangeFocalPoint` | `function` | `undefined` | Callback that gets called with the new focal point when it changes. (Is required for the FocalPointPicker to appear) |
 | `labels` | `object` | `{}` | Pass in an object of labels to be used by the `MediaPlaceholder` component under the hook. Allows the sub properties `title` and `instructions` |
 | `canEditImage` | `boolean` | `true` | whether or not the image can be edited by in the context its getting viewed. Controls whether a placeholder or upload controls should be shown when no image is present |
+| `allowedTypes` | `array` | `['image']` | Array of [unique file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers): file extensions, [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types), `image` |
 | `...rest` | `*` | `null` | any additional attributes you want to pass to the underlying `img` tag |


### PR DESCRIPTION


### Description of the Change

This PR:

- allows the `Image` component to enforce the use of a specific file type
- updates docs to add instructions
- updates example code to use this parameter

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #239 

### How to test the Change

Use the sample code provided in the Image component README. Verify that it does not accept, via upload or picking from the library, a file which is not a `.gif`.

### Changelog Entry

> Added - Image component now supports specifying filetype via `allowedTypes`

### Credits

Props @benlk


### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
