### PR TITLE
fix/278: add `id` to the default row

### DIFF
--- a/components/repeater/index.js
+++ b/components/repeater/index.js
@@ -42,6 +42,8 @@ export const AttributeRepeater = ({ children, attribute, addButton, allowReorder
 		};
 	});
 
+	defaultRepeaterData[0].id = uuid();
+
 	const handleOnChange = (value) => {
 		updateBlockAttributes(clientId, { [attribute]: value });
 	};


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

The reordering was broken due to the empty `id` parameter for the default row. This PR fixes it.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #278

### How to test the Change

Please follow the steps provided in the issue.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Broken Repeater component drag and drop reordering functionality


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ajmaurya99 @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
