### PR TITLE
Allow type number for Optional component property `value`

### DIFF
--- a/components/optional/index.js
+++ b/components/optional/index.js
@@ -11,6 +11,6 @@ Optional.defaultProps = {
 };
 
 Optional.propTypes = {
-	value: PropTypes.string || PropTypes.bool,
+	value: PropTypes.string || PropTypes.bool || PropTypes.number,
 	children: PropTypes.node.isRequired,
 };


### PR DESCRIPTION
### Description of the Change

Allow type number for Optional component property `value`.

Closes #282.

### How to test the Change
Have a block with an attribute of type `number` and use it for the `value` prop of `<Optional />`

### Changelog Entry
> Changed - Allow type number for Optional component property `value`.


### Credits
Props @ocean90.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
