### PR TITLE
Ensure search type has enough space

### DIFF
--- a/components/content-search/SearchItem.js
+++ b/components/content-search/SearchItem.js
@@ -36,6 +36,7 @@ const ButtonStyled = styled(Button)`
 		padding: 2px 4px;
 		text-transform: capitalize;
 		border-radius: 2px;
+		flex-shrink: 0;
 	}
 
 	.block-editor-link-control__search-item-header {


### PR DESCRIPTION
### Description of the Change

Use `flex-shrink: 0` to prevent unreadable search types.

Closes #285.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed: Width of search types in content picker


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ocean90


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
