### PR TITLE
upkeep:  Add TS support for `IsAdmin` component

### DIFF
--- a/components/is-admin/index.ts
+++ b/components/is-admin/index.ts
@@ -1,7 +1,14 @@
 import { useSelect } from '@wordpress/data';
 
 interface IsAdminProps {
+	/**
+	 * Fallback component.
+	 */
 	fallback: React.ReactNode | null;
+
+	/**
+	 * Child component.
+	 */
 	children: React.ReactNode;
 }
 
@@ -11,11 +18,6 @@ interface IsAdminProps {
  * A wrapper component that checks wether the current user has admin capabilities
  * and only returns the child components if the user is an admin. You can pass a
  * fallback component via the fallback prop.
- *
- * @param {object} props react props
- * @param {React.ReactNode|null} props.fallback fallback component
- * @param {React.ReactNode} props.children child components
- * @returns {null|React.ReactNode}
  */
 export const IsAdmin: React.FC<IsAdminProps> = ({
 	fallback = null,

--- a/components/is-admin/index.ts
+++ b/components/is-admin/index.ts
@@ -1,5 +1,10 @@
 import { useSelect } from '@wordpress/data';
 
+interface IsAdminProps {
+	fallback: React.ReactNode | null;
+	children: React.ReactNode;
+}
+
 /**
  * IsAdmin
  *
@@ -8,12 +13,15 @@ import { useSelect } from '@wordpress/data';
  * fallback component via the fallback prop.
  *
  * @param {object} props react props
- * @param {*} props.fallback fallback component
- * @param {*} props.children child components
- * @returns {*}
+ * @param {React.ReactNode|null} props.fallback fallback component
+ * @param {React.ReactNode} props.children child components
+ * @returns {null|React.ReactNode}
  */
-export const IsAdmin = ({ fallback = null, children }) => {
-	const hasAdminPermissions = useSelect(
+export const IsAdmin: React.FC<IsAdminProps> = ({
+	fallback = null,
+	children,
+}): null | React.ReactNode => {
+	const hasAdminPermissions: boolean = useSelect(
 		(select) => select('core').canUser('read', 'users?roles=1'),
 		[],
 	);

--- a/components/is-admin/index.tsx
+++ b/components/is-admin/index.tsx
@@ -22,7 +22,7 @@ interface IsAdminProps {
 export const IsAdmin: React.FC<IsAdminProps> = ({
 	fallback = null,
 	children,
-}): null | React.ReactNode => {
+}) => {
 	const hasAdminPermissions: boolean = useSelect(
 		(select) => select('core').canUser('read', 'users?roles=1'),
 		[],


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Add TS support to `IsAdmin` component


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
