### PR TITLE
Fix `useMedia()` example

### DIFF
--- a/hooks/use-media/readme.md
+++ b/hooks/use-media/readme.md
@@ -18,7 +18,7 @@ function BlockEdit(props) {
     }
 
     return (
-        <img src={ media.source_url } alt={image.alt} />
+        <img src={ media.source_url } alt={ media.alt_text } />
     );
 }
 ```


### PR DESCRIPTION

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Fixes the example for the `useMedia()` hook. Now uses `media.alt_text` to show the correct alt text of the media file.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Fixed - Fix example for `useMedia()` hook


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @soean


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
