### PR TITLE
upkeep: add TS support to `MediaToolbar` component

### DIFF
--- a/components/media-toolbar/index.tsx
+++ b/components/media-toolbar/index.tsx
@@ -1,8 +1,30 @@
 import { __ } from '@wordpress/i18n';
 import { MediaReplaceFlow, MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
-import PropTypes from 'prop-types';
 import { useMedia } from '../../hooks/use-media';
+import type { Attachment } from '@wordpress/core-data';
+
+interface MediaToolbarProps {
+	/**
+	 * Callback to handle the selection of a media.
+	 */
+	onSelect: (media: Attachment) => void;
+
+	/**
+	 * Callback to handle the removal of a media.
+	 */
+	onRemove: (event: React.MouseEvent<HTMLButtonElement>) => void;
+
+	/**
+	 * Wether or not the Remove Image button should be shown.
+	 */
+	isOptional?: boolean;
+
+	/**
+	 * The ID of the media, in this case the image.
+	 */
+	id: number;
+}
 
 /**
  * MediaToolbar
@@ -15,9 +37,7 @@ import { useMedia } from '../../hooks/use-media';
  * @param {object} props options
  * @returns {React.ReactElement} markup of the ToolbarGroup
  */
-export const MediaToolbar = (props) => {
-	const { onSelect, onRemove, isOptional = false, id } = props;
-
+export const MediaToolbar: React.FC<MediaToolbarProps> = ( { onSelect, onRemove, isOptional = false, id } ) => {
 	const hasImage = !!id;
 	const { media } = useMedia(id);
 
@@ -50,15 +70,4 @@ export const MediaToolbar = (props) => {
 			)}
 		</ToolbarGroup>
 	);
-};
-
-MediaToolbar.defaultProps = {
-	isOptional: false,
-};
-
-MediaToolbar.propTypes = {
-	id: PropTypes.number.isRequired,
-	onSelect: PropTypes.func.isRequired,
-	onRemove: PropTypes.func.isRequired,
-	isOptional: PropTypes.bool,
 };


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - add TS support to `MediaToolbar` component


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
