### PR TITLE
upkeep: add TS support for `PostMeta` component

### DIFF
--- a/components/post-meta/index.tsx
+++ b/components/post-meta/index.tsx
@@ -1,10 +1,26 @@
 import { RichText } from '@wordpress/block-editor';
 import { __experimentalNumberControl as NumberControl, ToggleControl } from '@wordpress/components';
-import PropTypes from 'prop-types';
+import type { ToggleControlProps } from '@wordpress/components/src/toggle-control/types';
 import { usePostMetaValue, useIsSupportedMetaField } from '../../hooks';
 import { toSentence } from './utilities';
 
-export const PostMeta = (props) => {
+interface PostMetaProps {
+	/**
+	 * The meta key to use.
+	 */
+	metaKey: string;
+
+	/**
+	 * The children render prop.
+	 */
+	children?: ((metaValue: any, setMetaValue: (value: any) => void) => React.ReactNode);
+}
+
+export const PostMeta: React.FC<PostMetaProps> & {
+	String: React.FC<MetaStringProps>;
+	Number: React.FC<MetaNumberProps>;
+	Boolean: React.FC<MetaBooleanProps>;
+} = (props) => {
 	const { metaKey, children } = props;
 	const [isSupported] = useIsSupportedMetaField(metaKey);
 	const [metaValue, setMetaValue] = usePostMetaValue(metaKey);
@@ -31,46 +47,51 @@ export const PostMeta = (props) => {
 	return <MetaString {...props} />;
 };
 
-PostMeta.propTypes = {
-	metaKey: PropTypes.string.isRequired,
-};
+interface MetaStringProps {
+	/**
+	 * The meta key to use.
+	 */
+	metaKey: string;
 
-const MetaString = (props) => {
+	/**
+	 * A valid HTML tag.
+	 */
+	tagName?: keyof JSX.IntrinsicElements;
+}
+
+const MetaString: React.FC<MetaStringProps> = (props) => {
 	const { metaKey, tagName = 'p' } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue(metaKey);
 
 	return <RichText value={metaValue} onChange={setMetaValue} tagName={tagName} {...props} />;
 };
 
-MetaString.propTypes = {
-	metaKey: PropTypes.string.isRequired,
-	tagName: PropTypes.string,
-};
+interface MetaNumberProps {
+	/**
+	 * The meta key to use.
+	 */
+	metaKey: string;
+}
 
-MetaString.defaultProps = {
-	tagName: 'p',
-};
-
-const MetaNumber = (props) => {
+const MetaNumber: React.FC<MetaNumberProps> = (props) => {
 	const { metaKey } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue(metaKey);
 
 	return <NumberControl value={metaValue} onChange={setMetaValue} {...props} />;
 };
 
-MetaNumber.propTypes = {
-	metaKey: PropTypes.string.isRequired,
-};
+interface MetaBooleanProps extends Pick<ToggleControlProps, 'label'> {
+	/**
+	 * The meta key to use.
+	 */
+	metaKey: string;
+}
 
-const MetaBoolean = (props) => {
+const MetaBoolean: React.FC<MetaBooleanProps> = (props) => {
 	const { metaKey } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue(metaKey);
 
 	return <ToggleControl checked={metaValue} onChange={setMetaValue} {...props} />;
-};
-
-MetaBoolean.propTypes = {
-	metaKey: PropTypes.string.isRequired,
 };
 
 PostMeta.String = MetaString;

--- a/components/post-meta/index.tsx
+++ b/components/post-meta/index.tsx
@@ -82,7 +82,7 @@ const MetaNumber: React.FC<MetaNumberProps> = (props) => {
 	const { metaKey } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue(metaKey);
 
-	return <NumberControl value={metaValue} onChange={setMetaValue} {...props} />;
+	return <NumberControl value={metaValue} onChange={value => setMetaValue(parseInt(value ?? ''))} {...props} />;
 };
 
 interface MetaBooleanProps extends Pick<ToggleControlProps, 'label'> {

--- a/components/post-meta/index.tsx
+++ b/components/post-meta/index.tsx
@@ -14,6 +14,11 @@ interface PostMetaProps {
 	 * The children render prop.
 	 */
 	children?: ((metaValue: any, setMetaValue: (value: any) => void) => React.ReactNode);
+
+	/**
+	 * Additional props to pass to the component.
+	 */
+	[key: string]: any;
 }
 
 export const PostMeta: React.FC<PostMetaProps> & {

--- a/components/post-meta/utilities.ts
+++ b/components/post-meta/utilities.ts
@@ -1,17 +1,17 @@
 // Checks whether character is Uppercase.
 // Crude version. Checks only A-Z.
-function isCaps(char) {
+function isCaps(char: string) {
 	if (char.match(/[A-Z]/)) return true;
 	return false;
 }
 
 // Checks whether character is digit.
-function isDigit(char) {
+function isDigit(char: string) {
 	if (char.match(/[0-9]/)) return true;
 	return false;
 }
 
-export function toKebab(string) {
+export function toKebab(string: string) {
 	return string
 		.split('')
 		.map((letter, index) => {
@@ -39,7 +39,7 @@ export function toKebab(string) {
 		.replace(/[-_\s]+/g, '-');
 }
 
-export function toSentence(string) {
+export function toSentence(string: string) {
 	const interim = toKebab(string).replace(/-/g, ' ');
 	return interim.slice(0, 1).toUpperCase() + interim.slice(1);
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - add TS support for PostMeta component


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
