### PR TITLE
Fix: styling of search results in ContentSearch component

### DIFF
--- a/components/content-search/SearchItem.js
+++ b/components/content-search/SearchItem.js
@@ -42,6 +42,7 @@ const ButtonStyled = styled(Button)`
 	.block-editor-link-control__search-item-header {
 		display: flex;
 		flex-direction: column;
+		align-items: flex-start;
 	}
 
 	mark {

--- a/components/content-search/index.js
+++ b/components/content-search/index.js
@@ -40,6 +40,14 @@ const LoadingContainer = styled.div`
 	}
 `;
 
+const StyledNavigableMenu = styled(NavigableMenu)`
+	width: 100%;
+`;
+
+const StyledSearchControl = styled(SearchControl)`
+	width: 100%;
+`;
+
 const ContentSearch = ({
 	onSelectItem,
 	placeholder,
@@ -353,8 +361,8 @@ const ContentSearch = ({
 
 	return (
 		<StyledComponentContext cacheKey="tenup-component-content-search">
-			<NavigableMenu onNavigate={handleOnNavigate} orientation="vertical">
-				<SearchControl
+			<StyledNavigableMenu onNavigate={handleOnNavigate} orientation="vertical">
+				<StyledSearchControl
 					__next40pxDefaultSize
 					value={searchString}
 					onChange={(newSearchString) => {
@@ -444,7 +452,7 @@ const ContentSearch = ({
 						{isLoading && currentPage > 1 && <StyledSpinner />}
 					</>
 				) : null}
-			</NavigableMenu>
+			</StyledNavigableMenu>
 		</StyledComponentContext>
 	);
 };


### PR DESCRIPTION
## What

Fix the visual appearance of how the Search Results of the Content Search component get rendered.

| Before | After |
|--------|--------|
| ![CleanShot 2024-04-16 at 08 13 00@2x](https://github.com/10up/block-components/assets/20684594/5fac4358-a586-402c-b3d8-baf4d8393665) | ![CleanShot 2024-04-16 at 08 09 27@2x](https://github.com/10up/block-components/assets/20684594/54f5f3e0-c72c-4061-ad5e-e0685f909cc1) | 

## Why

Because they were currently broken in WordPress 6.5

## How

By adding `align-items: start;` to the flex container so that the items are aligned to the start of the container.
