### PR TITLE
Fix: use unknown instead of any for unknown additional props

### DIFF
--- a/components/author/index.tsx
+++ b/components/author/index.tsx
@@ -4,7 +4,7 @@ import { useAuthor } from './context';
 
 interface NameProps {
   tagName?: keyof JSX.IntrinsicElements;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export const Name: React.FC<NameProps> = (props) => {
@@ -22,7 +22,7 @@ export const Name: React.FC<NameProps> = (props) => {
 
 interface FirstNameProps {
 	tagName?: keyof JSX.IntrinsicElements;
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export const FirstName: React.FC<FirstNameProps> = (props) => {
@@ -34,7 +34,7 @@ export const FirstName: React.FC<FirstNameProps> = (props) => {
 
 interface LastNameProps {
 	tagName?: keyof JSX.IntrinsicElements;
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export const LastName: React.FC<LastNameProps> = (props) => {
@@ -54,7 +54,7 @@ function useDefaultAvatar() {
 }
 
 interface AvatarProps {
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export const Avatar: React.FC<AvatarProps> = (props) => {
@@ -71,7 +71,7 @@ export const Avatar: React.FC<AvatarProps> = (props) => {
 
 interface BioProps {
 	tagName?: keyof JSX.IntrinsicElements;
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export const Bio: React.FC<BioProps> = (props) => {
@@ -82,7 +82,7 @@ export const Bio: React.FC<BioProps> = (props) => {
 };
 
 interface EmailProps {
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export const Email: React.FC<EmailProps> = (props) => {

--- a/components/post-author/index.tsx
+++ b/components/post-author/index.tsx
@@ -10,7 +10,7 @@ import type { Author } from '../author/context';
 
 interface PostAuthorProps {
 	children?: React.ReactNode | ((author: Author) => React.ReactNode);
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export const PostAuthor: React.FC<PostAuthorProps> & {

--- a/components/post-date/index.tsx
+++ b/components/post-date/index.tsx
@@ -41,7 +41,7 @@ interface PostDateProps {
 	/**
 	 * Remaining props to pass to the time element.
 	 */
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export const PostDate: React.FC<PostDateProps> = ({ placeholder = __('No date set', 'tenup'), format, ...rest}) => {

--- a/components/post-meta/index.tsx
+++ b/components/post-meta/index.tsx
@@ -18,7 +18,7 @@ interface PostMetaProps {
 	/**
 	 * Additional props to pass to the component.
 	 */
-	[key: string]: any;
+	[key: string]: unknown;
 }
 
 export const PostMeta: React.FC<PostMetaProps> & {

--- a/hooks/use-block-parent-attributes/index.ts
+++ b/hooks/use-block-parent-attributes/index.ts
@@ -18,7 +18,7 @@ export function useBlockParentAttributes() {
 
 	const { updateBlockAttributes } = useDispatch(blockEditorStore);
 
-	const setParentAttributes = (attributes: {[key: string]: any}) => {
+	const setParentAttributes = (attributes: {[key: string]: unknown}) => {
 		updateBlockAttributes(parentBlockClientId, attributes);
 	};
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

As called out by @Antonio-Laguna in a few CR's we should use `unknown` instead of `any` for unknown additional properties we type. 
