### PR TITLE
Fix: ensure `useOnClickOutside` hook correctly detects clicks across iframed editor boundaries

### DIFF
--- a/hooks/use-on-click-outside.ts
+++ b/hooks/use-on-click-outside.ts
@@ -3,6 +3,8 @@ import { useRefEffect } from '@wordpress/compose';
 /**
  * useOnClickOutside
  *
+ * Note: This hook is only intended to be used in the WordPress backend/block editor.
+ *
  * @param {Function} onClickOutside callback that will get invoked when the user clicks outside of the target
  * @returns {object} ref to the target element
  */

--- a/hooks/use-on-click-outside.ts
+++ b/hooks/use-on-click-outside.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
 
 /**
  * useOnClickOutside
@@ -7,29 +7,53 @@ import { useEffect, useRef } from '@wordpress/element';
  * @returns {object} ref to the target element
  */
 export function useOnClickOutside(onClickOutside: (event: MouseEvent | TouchEvent) => void) {
-	const ref = useRef<HTMLElement>();
-	useEffect(
-		() => {
+	const ref = useRefEffect(
+		(element) => {
+			if (!element) {
+				return;
+			}
 			const listener = (event: MouseEvent | TouchEvent) => {
 				// Do nothing if clicking ref's element or descendent elements
-				if (!ref.current || ref.current.contains(event.target as HTMLElement)) {
+				if (!element || element.contains(event.target as HTMLElement)) {
 					return;
 				}
 				onClickOutside(event);
 			};
-			document.addEventListener('mousedown', listener);
-			document.addEventListener('touchstart', listener);
+
+			const ownerDocument = element.ownerDocument || document;
+			const isRenderedInsideIframe = ownerDocument !== document;
+
+			const editorCanvasIframe = document.querySelector<HTMLIFrameElement>('[name="editor-canvas"]');
+			const editorCanvasDocument = editorCanvasIframe?.contentDocument;
+
+			ownerDocument.addEventListener('mousedown', listener);
+			ownerDocument.addEventListener('touchstart', listener);
+
+			// If the element is rendered inside an iframe, we need to listen to events on the parent document
+			// as well to detect clicks outside the iframe.
+			if (isRenderedInsideIframe) {
+				document.addEventListener('mousedown', listener);
+				document.addEventListener('touchstart', listener);
+
+			// If the element is rendered outside the editor canvas iframe, we need to listen to events on the editor canvas
+			// document as well to detect clicks inside the editor canvas.
+			} else if (editorCanvasDocument) {
+				editorCanvasDocument.addEventListener('mousedown', listener);
+				editorCanvasDocument.addEventListener('touchstart', listener);
+			}
 			return () => {
-				document.removeEventListener('mousedown', listener);
-				document.removeEventListener('touchstart', listener);
+				ownerDocument.removeEventListener('mousedown', listener);
+				ownerDocument.removeEventListener('touchstart', listener);
+				if (isRenderedInsideIframe) {
+					document.removeEventListener('mousedown', listener);
+					document.removeEventListener('touchstart', listener);
+				} else if (editorCanvasDocument) {
+					editorCanvasDocument.removeEventListener('mousedown', listener);
+					editorCanvasDocument.removeEventListener('touchstart', listener);
+				}
 			};
 		},
-		// Add ref and handler to effect dependencies
-		// It's worth noting that because passed in handler is a new function on every
-		// render that will cause this effect callback/cleanup to run every render.
-		// It's not a big deal but to optimize you can wrap handler in useCallback before
-		// passing it into this hook.
-		[ref, onClickOutside],
+		[onClickOutside],
 	);
 
 	return ref;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Update the `useOnClickOutside` hook to ensure it correctly detects clicks that happen outside / inside the iframed block editor.

This fixes an issue in the `Link` component that @ncoetzer identified. When the Link component is rendered in a block inside the editor iframe, the link popover didn't properly close when the user clicked outside the element. 

The cause for this was that the editor canvas iframe only actually contains the block content. Any additional UI elements such as the `<Popover>` component get rendered using portals outside of the iframe again. This lead the `useOnClickOutside` hook to not detect those changes properly and therefore not trigger the callback that should close the popover. 

This has been fixed by adding additional listeners that also listen inside / outside the iframe depending on where the element is getting rendered. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Link Control popover didn't close when rendered inside an iFramed editor. 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy @ncoetzer 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
