### PR TITLE
Remove: `defaultProps` & `propTypes` definitions from remaining components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
 		"import/no-extraneous-dependencies": 0,
 		"react/jsx-props-no-spreading": 0,
 		"jsdoc/check-tag-names": 0,
-		"import/extensions": 0
+		"import/extensions": 0,
+		"react/prop-types": 0
 	}
 }

--- a/api/register-block-extension/index.js
+++ b/api/register-block-extension/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-props-no-spreading */
 
 import { addFilter } from '@wordpress/hooks';

--- a/components/clipboard-button/index.tsx
+++ b/components/clipboard-button/index.tsx
@@ -38,10 +38,10 @@ interface ButtonLabels {
 }
 
 export const ClipboardButton: React.FC<ClipboardButtonProps> = ({
-	text,
-	disabled,
-	onSuccess,
-	labels,
+	text = '',
+	disabled = false,
+	onSuccess = () => {},
+	labels = {},
 }) => {
 	const [hasCopied, setHasCopied] = useState(false);
 	const copy = labels.copy ? labels.copy : __('Copy');
@@ -83,11 +83,4 @@ export const ClipboardButton: React.FC<ClipboardButtonProps> = ({
 			{hasCopied ? copied : copy}
 		</Button>
 	);
-};
-
-ClipboardButton.defaultProps = {
-	text: '',
-	disabled: false,
-	onSuccess: () => {},
-	labels: {},
 };

--- a/components/content-picker/PickedItem.js
+++ b/components/content-picker/PickedItem.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -51,7 +50,7 @@ function getType(mode) {
  * @param {number|string} props.id id of the item
  * @returns {*} React JSX
  */
-const PickedItem = ({ item, isOrderable, handleItemDelete, mode, id }) => {
+const PickedItem = ({ item, isOrderable = false, handleItemDelete, mode, id }) => {
 	const type = getType(mode);
 
 	const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
@@ -138,18 +137,6 @@ const PickedItem = ({ item, isOrderable, handleItemDelete, mode, id }) => {
 			</StyledCloseButton>
 		</li>
 	);
-};
-
-PickedItem.defaultProps = {
-	isOrderable: false,
-};
-
-PickedItem.propTypes = {
-	item: PropTypes.object.isRequired,
-	isOrderable: PropTypes.bool,
-	handleItemDelete: PropTypes.func.isRequired,
-	mode: PropTypes.string.isRequired,
-	id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };
 
 export default PickedItem;

--- a/components/content-picker/SortableList.js
+++ b/components/content-picker/SortableList.js
@@ -7,10 +7,15 @@ import {
 	useSensors,
 } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import PropTypes from 'prop-types';
 import PickedItem from './PickedItem';
 
-const SortableList = ({ posts, isOrderable, handleItemDelete, mode, setPosts }) => {
+const SortableList = ({
+	posts,
+	isOrderable = false,
+	handleItemDelete,
+	mode = 'post',
+	setPosts,
+}) => {
 	const hasMultiplePosts = posts.length > 1;
 
 	const items = posts.map((item) => item.uuid);
@@ -43,19 +48,6 @@ const SortableList = ({ posts, isOrderable, handleItemDelete, mode, setPosts }) 
 			</SortableContext>
 		</DndContext>
 	);
-};
-
-SortableList.defaultProps = {
-	isOrderable: false,
-	mode: 'post',
-};
-
-SortableList.propTypes = {
-	posts: PropTypes.array.isRequired,
-	isOrderable: PropTypes.bool,
-	handleItemDelete: PropTypes.func.isRequired,
-	mode: PropTypes.string,
-	setPosts: PropTypes.func.isRequired,
 };
 
 export default SortableList;

--- a/components/content-picker/index.js
+++ b/components/content-picker/index.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { select } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -43,7 +42,7 @@ const ContentPickerWrapper = styled.div`
  * @param {Array} props.contentTypes array of content types to filter by
  * @param {string} props.placeholder placeholder text for the search input
  * @param {Function} props.onPickChange callback for when the picker changes
- * @param {Function} props.queryFilter callback that allows to modify the query
+ * @param {?Function} props.queryFilter callback that allows to modify the query
  * @param {number} props.maxContentItems max number of items to show in the picker
  * @param {boolean} props.isOrderable whether or not the picker is sortable
  * @param {string} props.singlePickedLabel label for the single picked item
@@ -54,28 +53,30 @@ const ContentPickerWrapper = styled.div`
  * @param {number} props.perPage number of items to show per page
  * @param {boolean} props.fetchInitialResults whether or not to fetch initial results on mount
  * @param {Function} props.renderItemType callback to render the item type
- * @param {Function} props.renderItem react component to render the search result item
+ * @param {?Function} props.renderItem react component to render the search result item
  * @returns {*} React JSX
  */
-const ContentPicker = ({
-	label,
-	hideLabelFromVision,
-	mode,
-	contentTypes,
-	placeholder,
-	onPickChange,
-	queryFilter,
-	maxContentItems,
-	isOrderable,
-	singlePickedLabel,
-	multiPickedLabel,
-	content,
-	uniqueContentItems,
-	excludeCurrentPost,
-	perPage,
-	fetchInitialResults,
-	renderItemType,
-	renderItem,
+export const ContentPicker = ({
+	label = '',
+	hideLabelFromVision = true,
+	mode = 'post',
+	contentTypes = ['post', 'page'],
+	placeholder = '',
+	onPickChange = (ids) => {
+		console.log('Content picker list change', ids); // eslint-disable-line no-console
+	},
+	queryFilter = null,
+	maxContentItems = 1,
+	isOrderable = false,
+	singlePickedLabel = __('You have selected the following item:', '10up-block-components'),
+	multiPickedLabel = __('You have selected the following items:', '10up-block-components'),
+	content = [],
+	uniqueContentItems = true,
+	excludeCurrentPost = true,
+	perPage = 20,
+	fetchInitialResults = false,
+	renderItemType = defaultRenderItemType,
+	renderItem = null,
 }) => {
 	const currentPostId = select('core/editor')?.getCurrentPostId();
 
@@ -187,49 +188,3 @@ const ContentPicker = ({
 		</StyledComponentContext>
 	);
 };
-
-ContentPicker.defaultProps = {
-	label: '',
-	hideLabelFromVision: true,
-	mode: 'post',
-	onPickChange: (ids) => {
-		console.log('Content picker list change', ids); // eslint-disable-line no-console
-	},
-	queryFilter: undefined,
-	contentTypes: ['post', 'page'],
-	placeholder: '',
-	content: [],
-	perPage: 20,
-	maxContentItems: 1,
-	uniqueContentItems: true,
-	isOrderable: false,
-	excludeCurrentPost: true,
-	multiPickedLabel: __('You have selected the following items:', '10up-block-components'),
-	singlePickedLabel: __('You have selected the following item:', '10up-block-components'),
-	fetchInitialResults: false,
-	renderItemType: defaultRenderItemType,
-	renderItem: undefined,
-};
-
-ContentPicker.propTypes = {
-	contentTypes: PropTypes.array,
-	content: PropTypes.array,
-	placeholder: PropTypes.string,
-	mode: PropTypes.oneOf(['post', 'user', 'term']),
-	label: PropTypes.string,
-	hideLabelFromVision: PropTypes.bool,
-	multiPickedLabel: PropTypes.string,
-	singlePickedLabel: PropTypes.string,
-	isOrderable: PropTypes.bool,
-	onPickChange: PropTypes.func,
-	queryFilter: PropTypes.func,
-	uniqueContentItems: PropTypes.bool,
-	excludeCurrentPost: PropTypes.bool,
-	maxContentItems: PropTypes.number,
-	perPage: PropTypes.number,
-	fetchInitialResults: PropTypes.bool,
-	renderItemType: PropTypes.func,
-	renderItem: PropTypes.func,
-};
-
-export { ContentPicker };

--- a/components/custom-block-appender/index.js
+++ b/components/custom-block-appender/index.js
@@ -1,12 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
-/**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-
-/**
- * WordPress dependencies
- */
 import { Inserter } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 
@@ -25,8 +16,8 @@ import { Button } from '@wordpress/components';
  */
 const CustomBlockAppender = ({
 	rootClientId,
-	buttonText,
-	icon,
+	buttonText = '',
+	icon = 'plus',
 	className = 'custom-block-appender',
 	...buttonProps
 }) => {
@@ -47,21 +38,6 @@ const CustomBlockAppender = ({
 			)}
 		/>
 	);
-};
-
-CustomBlockAppender.propTypes = {
-	rootClientId: PropTypes.string.isRequired,
-	buttonText: PropTypes.string,
-	label: PropTypes.string,
-	icon: PropTypes.string,
-	className: PropTypes.string,
-};
-
-CustomBlockAppender.defaultProps = {
-	buttonText: '',
-	label: '',
-	icon: 'plus',
-	className: 'custom-block-appender',
 };
 
 export { CustomBlockAppender };

--- a/components/image/index.js
+++ b/components/image/index.js
@@ -1,17 +1,16 @@
 import { MediaPlaceholder, InspectorControls } from '@wordpress/block-editor';
 import { Spinner, FocalPointPicker, PanelBody, Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 
 import { useMedia } from '../../hooks/use-media';
 
-const Image = (props) => {
+export const Image = (props) => {
 	const {
 		id,
 		size = 'full',
 		onSelect,
 		focalPoint = { x: 0.5, y: 0.5 },
-		onChangeFocalPoint,
+		onChangeFocalPoint = undefined,
 		labels = {},
 		canEditImage = true,
 		allowedTypes = ['image'],
@@ -74,32 +73,4 @@ const Image = (props) => {
 			<img src={imageUrl} alt={altText} {...rest} />
 		</>
 	);
-};
-
-export { Image };
-
-Image.defaultProps = {
-	size: 'large',
-	focalPoint: { x: 0.5, y: 0.5 },
-	onChangeFocalPoint: undefined,
-	labels: {},
-	canEditImage: true,
-	allowedTypes: ['image'],
-};
-
-Image.propTypes = {
-	id: PropTypes.number.isRequired,
-	size: PropTypes.string,
-	onSelect: PropTypes.func.isRequired,
-	onChangeFocalPoint: PropTypes.func,
-	allowedTypes: PropTypes.array,
-	focalPoint: PropTypes.shape({
-		x: PropTypes.string,
-		y: PropTypes.string,
-	}),
-	labels: PropTypes.shape({
-		title: PropTypes.string,
-		instructions: PropTypes.string,
-	}),
-	canEditImage: PropTypes.bool,
 };

--- a/components/inner-block-slider/index.js
+++ b/components/inner-block-slider/index.js
@@ -1,23 +1,20 @@
 /* eslint-disable */
 // @ts-nocheck
-// eslint-disable-file
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState, useRef } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import { useInnerBlocksProps } from '@wordpress/block-editor';
 import deprecated from '@wordpress/deprecated';
-import PropTypes from 'prop-types';
 /** @jsx jsx */
-// eslint-disable-next-line no-unused-vars
 import { jsx, css } from '@emotion/react';
 import { ChevronLeft, ChevronRight } from './icons';
 
-const InnerBlockSlider = ({
+export const InnerBlockSlider = ({
 	parentBlockId,
-	slidesPerPage,
+	slidesPerPage = 1,
 	allowedBlock,
-	template,
-	slideHeight,
+	template = null,
+	slideHeight = null,
 }) => {
 	const [currentPage, setCurrentPage] = useState(1);
 
@@ -173,19 +170,3 @@ const InnerBlockSlider = ({
 		</div>
 	);
 };
-
-InnerBlockSlider.defaultProps = {
-	slidesPerPage: 1,
-	template: null,
-	slideHeight: null,
-};
-
-InnerBlockSlider.propTypes = {
-	slidesPerPage: PropTypes.number,
-	parentBlockId: PropTypes.string.isRequired,
-	allowedBlock: PropTypes.string.isRequired,
-	template: PropTypes.array,
-	slideHeight: PropTypes.string,
-};
-
-export { InnerBlockSlider };

--- a/components/link/index.js
+++ b/components/link/index.js
@@ -3,7 +3,6 @@
  */
 import classnames from 'classnames';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 /**
  * WordPress dependencies
@@ -105,17 +104,17 @@ const StylesRichTextLink = styled(RichText)`
  *
  * @returns {*} The rendered component.
  */
-const Link = ({
-	value,
-	type,
+export const Link = ({
+	value = undefined,
+	type = '',
 	opensInNewTab,
-	url,
+	url = undefined,
 	onLinkChange,
 	onTextChange,
-	onLinkRemove,
-	kind,
-	placeholder,
-	className,
+	onLinkRemove = null,
+	kind = '',
+	placeholder = __('Link text ...', '10up-block-components'),
+	className = undefined,
 	...rest
 }) => {
 	const [isPopoverVisible, setIsPopoverVisible] = useState(false);
@@ -201,28 +200,3 @@ const Link = ({
 		</StyledComponentContext>
 	);
 };
-
-Link.defaultProps = {
-	value: undefined,
-	url: undefined,
-	className: undefined,
-	onLinkRemove: null,
-	type: '',
-	kind: '',
-	placeholder: __('Link text ...', '10up-block-components'),
-};
-
-Link.propTypes = {
-	value: PropTypes.string,
-	url: PropTypes.string,
-	onLinkChange: PropTypes.func.isRequired,
-	onLinkRemove: PropTypes.func,
-	onTextChange: PropTypes.func.isRequired,
-	opensInNewTab: PropTypes.bool.isRequired,
-	type: PropTypes.string,
-	kind: PropTypes.string,
-	className: PropTypes.string,
-	placeholder: PropTypes.string,
-};
-
-export { Link };

--- a/components/post-category-list/index.js
+++ b/components/post-category-list/index.js
@@ -1,14 +1,8 @@
-import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import { PostTermList } from '../post-term-list';
 
-export const PostCategoryList = PostTermList;
-
-PostCategoryList.propTypes = {
-	taxonomyName: PropTypes.string,
-};
-
-PostCategoryList.defaultProps = {
-	taxonomyName: 'category',
-	noResultsMessage: __('Please select a category', 'tenup'),
-};
+export const PostCategoryList = ({
+	taxonomyName = 'category',
+	noResultsMessage = __('Please select a category', 'tenup'),
+	...rest
+}) => <PostTermList taxonomyName={taxonomyName} noResultsMessage={noResultsMessage} {...rest} />;

--- a/components/post-context/index.js
+++ b/components/post-context/index.js
@@ -1,9 +1,8 @@
-import PropTypes from 'prop-types';
 import { useMemo } from '@wordpress/element';
-import { DEFAULT_POST_CONTEXT, PostContext as PostContextContext } from './context';
+import { PostContext as PostContextContext } from './context';
 
 export const PostContext = (props) => {
-	const { children, postId, postType, isEditable } = props;
+	const { children, postId = null, postType = null, isEditable = null } = props;
 
 	const value = useMemo(
 		() => ({
@@ -16,12 +15,3 @@ export const PostContext = (props) => {
 
 	return <PostContextContext.Provider value={value}>{children}</PostContextContext.Provider>;
 };
-
-PostContext.propTypes = {
-	children: PropTypes.node.isRequired,
-	postId: PropTypes.number,
-	postType: PropTypes.string,
-	isEditable: PropTypes.bool,
-};
-
-PostContext.defaultProps = DEFAULT_POST_CONTEXT;

--- a/components/post-excerpt/index.js
+++ b/components/post-excerpt/index.js
@@ -1,7 +1,6 @@
 import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
-import PropTypes from 'prop-types';
 import { usePost } from '../../hooks';
 
 export const PostExcerpt = (props) => {
@@ -30,12 +29,4 @@ export const PostExcerpt = (props) => {
 			{...rest}
 		/>
 	);
-};
-
-PostExcerpt.propTypes = {
-	placeholder: PropTypes.string,
-};
-
-PostExcerpt.defaultProps = {
-	placeholder: __('Enter excerpt...', 'tenup'),
 };

--- a/components/post-primary-category/index.js
+++ b/components/post-primary-category/index.js
@@ -1,17 +1,16 @@
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { PostPrimaryTerm } from '../post-primary-term';
 
-export const PostPrimaryCategory = PostPrimaryTerm;
-
-PostPrimaryCategory.propTypes = {
-	placeholder: PropTypes.string,
-	taxonomyName: PropTypes.string,
-	isLink: PropTypes.bool,
-};
-
-PostPrimaryCategory.defaultProps = {
-	placeholder: __('Select a category', 'tenup'),
-	taxonomyName: 'category',
-	isLink: true,
-};
+export const PostPrimaryCategory = ({
+	placeholder = __('Select a category', 'tenup'),
+	taxonomyName = 'category',
+	isLink = true,
+	...rest
+}) => (
+	<PostPrimaryTerm
+		placeholder={placeholder}
+		taxonomyName={taxonomyName}
+		isLink={isLink}
+		{...rest}
+	/>
+);

--- a/components/post-primary-term/index.js
+++ b/components/post-primary-term/index.js
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { usePrimaryTerm } from '../../hooks';
 
 export const PostPrimaryTerm = (props) => {
@@ -32,16 +31,4 @@ export const PostPrimaryTerm = (props) => {
 	}
 
 	return <Tag {...wrapperProps}>{termString}</Tag>;
-};
-
-PostPrimaryTerm.propTypes = {
-	placeholder: PropTypes.string,
-	taxonomyName: PropTypes.string,
-	isLink: PropTypes.bool,
-};
-
-PostPrimaryTerm.defaultProps = {
-	placeholder: __('Select a Term', 'tenup'),
-	isLink: true,
-	taxonomyName: 'category',
 };

--- a/components/post-term-list/index.js
+++ b/components/post-term-list/index.js
@@ -1,7 +1,6 @@
 import { Spinner } from '@wordpress/components';
 import { Children } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import {
 	PostTaxonomiesHierarchicalTermSelector,
 	PostTaxonomiesFlatTermSelector,
@@ -15,8 +14,8 @@ import { ListItem, TermLink } from './item';
 export const PostTermList = (props) => {
 	const {
 		tagName: TagName = 'ul',
-		taxonomyName,
-		children,
+		taxonomyName = 'category',
+		children = null,
 		noResultsMessage = __('Please select a term', 'tenup'),
 		...rest
 	} = props;
@@ -107,20 +106,6 @@ export const PostTermList = (props) => {
 			)}
 		</>
 	);
-};
-
-PostTermList.propTypes = {
-	children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-	taxonomyName: PropTypes.string,
-	tagName: PropTypes.string,
-	noResultsMessage: PropTypes.string,
-};
-
-PostTermList.defaultProps = {
-	children: null,
-	tagName: 'ul',
-	taxonomyName: 'category',
-	noResultsMessage: __('Please select a term', 'tenup'),
 };
 
 PostTermList.ListItem = ListItem;

--- a/components/post-term-list/item.js
+++ b/components/post-term-list/item.js
@@ -1,20 +1,10 @@
 import { useContext } from '@wordpress/element';
-import PropTypes from 'prop-types';
 import { PostTermContext } from './context';
 
 export const ListItem = (props) => {
 	const { tagName: TagName = 'li', children, ...rest } = props;
 
 	return <TagName {...rest}>{children}</TagName>;
-};
-
-ListItem.propTypes = {
-	tagName: PropTypes.string,
-	children: PropTypes.node.isRequired,
-};
-
-ListItem.defaultProps = {
-	tagName: 'li',
 };
 
 export const TermLink = (props) => {

--- a/components/repeater/index.js
+++ b/components/repeater/index.js
@@ -4,7 +4,6 @@ import { useSelect, dispatch } from '@wordpress/data';
 import { cloneElement } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -37,7 +36,7 @@ import { DragHandle } from '../drag-handle';
  * @param {string} props.id A string identifier for a repeater item.
  * @returns {*} React JSX
  */
-const SortableItem = ({ children, item, setItem, removeItem, id }) => {
+const SortableItem = ({ children, item = {}, setItem = null, removeItem = null, id = '' }) => {
 	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
 		id,
 	});
@@ -83,11 +82,11 @@ const SortableItem = ({ children, item, setItem, removeItem, id }) => {
  */
 export const AbstractRepeater = ({
 	children,
-	addButton,
-	allowReordering,
+	addButton = null,
+	allowReordering = false,
 	onChange,
 	value,
-	defaultValue,
+	defaultValue = [],
 }) => {
 	const sensors = useSensors(
 		useSensor(PointerSensor),
@@ -219,7 +218,12 @@ export const AbstractRepeater = ({
 	);
 };
 
-export const AttributeRepeater = ({ children, attribute, addButton, allowReordering }) => {
+export const AttributeRepeater = ({
+	children,
+	attribute = null,
+	addButton = null,
+	allowReordering = false,
+}) => {
 	const { clientId, name } = useBlockEditContext();
 	const { updateBlockAttributes } = dispatch(blockEditorStore);
 
@@ -258,12 +262,12 @@ export const AttributeRepeater = ({ children, attribute, addButton, allowReorder
 
 export const Repeater = ({
 	children,
-	addButton,
-	allowReordering,
+	addButton = null,
+	allowReordering = false,
 	onChange,
 	value,
-	defaultValue,
-	attribute,
+	defaultValue = [],
+	attribute = null,
 }) => {
 	if (attribute) {
 		return (
@@ -288,68 +292,4 @@ export const Repeater = ({
 			{children}
 		</AbstractRepeater>
 	);
-};
-
-Repeater.propTypes = {
-	children: PropTypes.func.isRequired,
-	addButton: PropTypes.func,
-	attribute: PropTypes.string,
-	allowReordering: PropTypes.bool,
-	onChange: PropTypes.func.isRequired,
-	value: PropTypes.array.isRequired,
-	defaultValue: PropTypes.array,
-};
-
-Repeater.defaultProps = {
-	attribute: null,
-	addButton: null,
-	allowReordering: false,
-	defaultValue: [],
-};
-
-AttributeRepeater.propTypes = {
-	children: PropTypes.func.isRequired,
-	attribute: PropTypes.string,
-	addButton: PropTypes.func,
-	allowReordering: PropTypes.bool,
-};
-
-AttributeRepeater.defaultProps = {
-	attribute: null,
-	addButton: null,
-	allowReordering: false,
-};
-
-AbstractRepeater.propTypes = {
-	children: PropTypes.func.isRequired,
-	addButton: PropTypes.func,
-	allowReordering: PropTypes.bool,
-	onChange: PropTypes.func.isRequired,
-	value: PropTypes.array.isRequired,
-	defaultValue: PropTypes.array,
-};
-
-AbstractRepeater.defaultProps = {
-	addButton: null,
-	allowReordering: false,
-	defaultValue: [],
-};
-
-SortableItem.defaultProps = {
-	attribute: 'items',
-	addItem: null,
-	setItem: null,
-	removeItem: null,
-	item: {},
-	id: '',
-};
-
-SortableItem.propTypes = {
-	children: PropTypes.func.isRequired,
-	attribute: PropTypes.string,
-	addItem: PropTypes.func,
-	setItem: PropTypes.func,
-	removeItem: PropTypes.func,
-	item: PropTypes.object,
-	id: PropTypes.string,
 };

--- a/components/rich-text-character-limit/index.js
+++ b/components/rich-text-character-limit/index.js
@@ -2,7 +2,6 @@ import { useState, useEffect } from '@wordpress/element';
 import { RichText, useBlockEditContext } from '@wordpress/block-editor';
 import { create, remove, getTextContent, toHTMLString } from '@wordpress/rich-text';
 import { useFloating, autoUpdate } from '@floating-ui/react-dom';
-import PropTypes from 'prop-types';
 import { Counter } from '../counter';
 
 /**
@@ -118,15 +117,3 @@ const RichTextCharacterLimit = (props) => {
 };
 
 export { RichTextCharacterLimit, getCharacterCount };
-
-RichTextCharacterLimit.defaultProps = {
-	limit: 100,
-	enforce: true,
-};
-
-RichTextCharacterLimit.propTypes = {
-	limit: PropTypes.number,
-	enforce: PropTypes.bool,
-	value: PropTypes.string.isRequired,
-	onChange: PropTypes.func.isRequired,
-};

--- a/hooks/use-popover/index.js
+++ b/hooks/use-popover/index.js
@@ -20,7 +20,6 @@ export const usePopover = () => {
 	const ref = useOnClickOutside(() => setIsVisible(false));
 	const PopoverComponent = useMemo(
 		() =>
-			// eslint-disable-next-line react/prop-types
 			({ children }) => {
 				if (!isVisible) {
 					return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@typescript-eslint/parser": "^6.21.0",
         "@wordpress/icons": "^10.0.0",
         "array-move": "^4.0.0",
-        "prop-types": "^15.8.1",
         "react-window": "^1.8.10",
         "uuid": "^9.0.1",
         "wp-types": "^3.65.0"
@@ -20748,6 +20747,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -22973,6 +22973,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -22982,6 +22983,7 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@typescript-eslint/parser": "^6.21.0",
     "@wordpress/icons": "^10.0.0",
     "array-move": "^4.0.0",
-    "prop-types": "^15.8.1",
     "react-window": "^1.8.10",
     "uuid": "^9.0.1",
     "wp-types": "^3.65.0"


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

The end goal still is to convert all of these to TypeScript as tracked in #295. However this is meant to close #314 before WordPress 6.6 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #314

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Refactor `defaultProps` to inline default assignements
> Removed - `prop-types` definition from the codebase



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
