### PR TITLE
Feature: Allow passing custom labels to `MediaToolbar` component

### DIFF
--- a/components/media-toolbar/index.tsx
+++ b/components/media-toolbar/index.tsx
@@ -50,9 +50,9 @@ export const MediaToolbar: React.FC<MediaToolbarProps> = ({
 	isOptional = false,
 	id,
 	labels = {
-		replace: __('Replace Image', '10up-block-components'),
-		remove: __('Remove Image', '10up-block-components'),
 		add: __('Add Image', '10up-block-components'),
+		remove: __('Remove Image', '10up-block-components'),
+		replace: __('Replace Image', '10up-block-components'),
 	},
 }) => {
 	const hasImage = !!id;

--- a/components/media-toolbar/index.tsx
+++ b/components/media-toolbar/index.tsx
@@ -25,6 +25,15 @@ interface MediaToolbarProps {
 	 * The ID of the media, in this case the image.
 	 */
 	id: number;
+
+	/**
+	 * Labels for the buttons.
+	 */
+	labels?: {
+		replace?: string;
+		remove?: string;
+		add?: string;
+	};
 }
 
 /*
@@ -40,6 +49,11 @@ export const MediaToolbar: React.FC<MediaToolbarProps> = ({
 	onRemove,
 	isOptional = false,
 	id,
+	labels = {
+		replace: __('Replace Image', '10up-block-components'),
+		remove: __('Remove Image', '10up-block-components'),
+		add: __('Add Image', '10up-block-components'),
+	},
 }) => {
 	const hasImage = !!id;
 	const { media } = useMedia(id);
@@ -51,11 +65,11 @@ export const MediaToolbar: React.FC<MediaToolbarProps> = ({
 					<MediaReplaceFlow
 						mediaUrl={media?.source_url}
 						onSelect={onSelect}
-						name={__('Replace Image', '10up-block-components')}
+						name={labels.replace}
 					/>
 					{!!isOptional && (
 						<ToolbarButton onClick={onRemove}>
-							{__('Remove Image', '10up-block-components')}
+							{labels.remove}
 						</ToolbarButton>
 					)}
 				</>
@@ -65,7 +79,7 @@ export const MediaToolbar: React.FC<MediaToolbarProps> = ({
 						onSelect={onSelect}
 						render={({ open }) => (
 							<ToolbarButton onClick={open}>
-								{__('Add Image', '10up-block-components')}
+								{labels.add}
 							</ToolbarButton>
 						)}
 					/>

--- a/components/media-toolbar/index.tsx
+++ b/components/media-toolbar/index.tsx
@@ -36,6 +36,12 @@ interface MediaToolbarProps {
 	};
 }
 
+const DEFAULT_LABELS = {
+	add: __('Add Image', '10up-block-components'),
+	remove: __('Remove Image', '10up-block-components'),
+	replace: __('Replace Image', '10up-block-components'),
+};
+
 /*
  * MediaToolbar
  *
@@ -49,14 +55,11 @@ export const MediaToolbar: React.FC<MediaToolbarProps> = ({
 	onRemove,
 	isOptional = false,
 	id,
-	labels = {
-		add: __('Add Image', '10up-block-components'),
-		remove: __('Remove Image', '10up-block-components'),
-		replace: __('Replace Image', '10up-block-components'),
-	},
+	labels = {},
 }) => {
 	const hasImage = !!id;
 	const { media } = useMedia(id);
+	const mergedLabels = { ...DEFAULT_LABELS, ...labels };
 
 	return (
 		<ToolbarGroup>
@@ -65,11 +68,11 @@ export const MediaToolbar: React.FC<MediaToolbarProps> = ({
 					<MediaReplaceFlow
 						mediaUrl={media?.source_url}
 						onSelect={onSelect}
-						name={labels.replace}
+						name={mergedLabels.replace}
 					/>
 					{!!isOptional && (
 						<ToolbarButton onClick={onRemove}>
-							{labels.remove}
+							{mergedLabels.remove}
 						</ToolbarButton>
 					)}
 				</>
@@ -79,7 +82,7 @@ export const MediaToolbar: React.FC<MediaToolbarProps> = ({
 						onSelect={onSelect}
 						render={({ open }) => (
 							<ToolbarButton onClick={open}>
-								{labels.add}
+								{mergedLabels.add}
 							</ToolbarButton>
 						)}
 					/>

--- a/components/media-toolbar/readme.md
+++ b/components/media-toolbar/readme.md
@@ -5,6 +5,7 @@ The MediaToolbar component is build to quickly add a complete media editing expe
 ## Usage
 
 ```js
+import { __ } from '@wordpress/i18n';
 import { BlockControls } from '@wordpress/block-editor';
 import { MediaToolbar } from '@10up/block-components';
 
@@ -28,6 +29,11 @@ function BlockEdit(props) {
                     id={ imageId }
                     onSelect={ handleImageSelect }
                     onRemove={ handleImageRemove }
+                    labels={{
+                        add: __('Custom add label'),
+                        remove: __('Custom remove label'),
+                        replace: __('Custom replace label'), 
+                    }}
                 />
             </BlockControls>
             ...
@@ -43,4 +49,5 @@ function BlockEdit(props) {
 | `id` | `number`    | `null`   | image id          |
 | `onSelect` | `Function` | `null` | Callback that gets called with the new image when one is selected |
 | `onRemove` | `Function` | `null` | Callback that gets called when the remove image button is clicked |
-| `isOptional` | `boolean` | `false` | Wether or not the Remove Image button should be shown |
+| `isOptional` | `boolean` | `false` | Whether or not the Remove Image button should be shown |
+| `labels`     | `object` | `{}` | Custom labels prop. Used to override default labels for better UX when using different media types. Allows the sub properties `add`, `remove`, and `replace`. |

--- a/example/src/blocks/custom-media-example/block.json
+++ b/example/src/blocks/custom-media-example/block.json
@@ -1,0 +1,18 @@
+{
+	"name": "example/custom-media-example",
+	"apiVersion": 3,
+	"title": "Custom Media Example",
+	"description": "Example Block to show the custom media toolbar in usage",
+	"icon": "smiley",
+	"category": "common",
+	"example": {},
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"imageId": {
+			"type": "number"
+		}
+	},
+	"editorScript": "file:./index.ts"
+}

--- a/example/src/blocks/custom-media-example/edit.tsx
+++ b/example/src/blocks/custom-media-example/edit.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { BlockControls, useBlockProps } from '@wordpress/block-editor';
+
+import { Image, MediaToolbar } from '@10up/block-components';
+
+export function BlockEdit(props) {
+    const {
+        attributes,
+        setAttributes
+    } = props;
+
+    const { imageId, focalPoint } = attributes;
+    const blockProps = useBlockProps();
+
+    const handleImageSelection = value => {
+        setAttributes({imageId: value.id })
+    };
+    const removeImage = () => setAttributes({imageId: null});
+
+	const handleFocalPointChange = value => {
+		setAttributes({focalPoint: value})
+	};
+
+    return (
+        <>
+            <BlockControls>
+                <MediaToolbar
+                    id={imageId}
+                    onSelect={ handleImageSelection }
+                    isOptional={true}
+                    onRemove={removeImage}
+                    labels={{
+                        replace: __('Replace your gif'),
+                        remove: __('Remove the gif'),
+                        add: __('Add a gif')
+                    }}
+                />
+            </BlockControls>
+            <div {...blockProps}>
+                <h2>Hello World!</h2>
+                <Image
+                    id={imageId}
+                    size="large"
+                    onSelect={handleImageSelection}
+                    className="example-image"
+                    allowedTypes={['image/gif']}
+                    labels={{
+                        title: __('Select a gif image'),
+                        instructions: __('Upload a gif or pick one from your media library.')
+                    }}
+                />
+            </div>
+        </>
+    )
+}

--- a/example/src/blocks/custom-media-example/index.ts
+++ b/example/src/blocks/custom-media-example/index.ts
@@ -1,0 +1,10 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+import { BlockEdit } from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata, {
+    edit: BlockEdit,
+    save: () => null
+} );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/block-components/issues/242

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Check out this branch locally
2. Run the WP environment
3. Add / edit a post
4. Add the 'custom media toolbar' block
5. Confirm updated labels 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Added - Support for custom labels in `MediaToolbar`
Fixed - Typo in documentation
Added - Custom media toolbar example

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
@Firestorm980 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
