### PR TITLE
Fix: Content picker check whether item.subtype is truthy before using it

### DIFF
--- a/components/content-picker/index.tsx
+++ b/components/content-picker/index.tsx
@@ -98,7 +98,7 @@ export const ContentPicker: React.FC<ContentPickerProps> = ({
 			{
 				id: item.id,
 				uuid: uuidv4(),
-				type: 'subtype' in item ? item.subtype : item.type,
+				type: 'subtype' in item && item.subtype ? item.subtype : item.type,
 			},
 			...content,
 		];


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

The `ContentPicker` can be used to fetch items of different types. Taxonomy Terms for example. These don't have a `subtype` property defined. But unlike the code assumed the actual `subtype` key is sometimes present but the value is `undefined`. This case is now also handled. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #335 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Don't delete picked items if the subtype is not set 

