### PR TITLE
Display decoded HTML entities in `PostPrimaryCategory` component

### DIFF
--- a/components/post-primary-term/index.tsx
+++ b/components/post-primary-term/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 import { usePrimaryTerm } from '../../hooks';
 
 interface PostPrimaryTermProps {
@@ -50,5 +51,5 @@ export const PostPrimaryTerm = ({
 		wrapperProps.href = termUrl;
 	}
 
-	return <Tag {...wrapperProps}>{termString}</Tag>;
+	return <Tag {...wrapperProps}>{decodeEntities(termString)}</Tag>;
 };

--- a/example/src/blocks/primary-category/block.json
+++ b/example/src/blocks/primary-category/block.json
@@ -1,0 +1,14 @@
+{
+	"apiVersion": 3,
+	"name": "example/primary-category",
+	"title": "Post Primary Category",
+	"icon": "archive",
+	"category": "common",
+	"example": {},
+	"supports": {
+		"html": false
+	},
+	"attributes": {},
+	"variations": [],
+	"editorScript": "file:./index.ts"
+}

--- a/example/src/blocks/primary-category/edit.tsx
+++ b/example/src/blocks/primary-category/edit.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useBlockProps } from '@wordpress/block-editor';
+import { PostPrimaryCategory } from '@10up/block-components';
+
+export const BlockEdit = ({context}) => {
+	const blockProps = useBlockProps();
+	return (
+		<div {...blockProps}>
+			<PostPrimaryCategory />
+		</div>
+	)
+};

--- a/example/src/blocks/primary-category/index.ts
+++ b/example/src/blocks/primary-category/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+import metadata from './block.json';
+import { BlockEdit } from './edit';
+
+
+registerBlockType( metadata, {
+    edit: BlockEdit,
+    save: () => null
+});


### PR DESCRIPTION

### Description of the Change

Currently, the PostPrimaryCategory component displays encoded HTML entities. This PR addresses that by utilizing `decodeEntities` to properly display the category name.

##### Before:

![image](https://github.com/user-attachments/assets/37878155-ebbe-4e96-8e32-e43291e07da0)

##### After:

![image](https://github.com/user-attachments/assets/3e933da1-73d0-477c-84fa-a5c2a1a8c5e2)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
1. Create a category with an ampersand
2. Use the `PostPrimaryCategory` component to display the category in the block editor
3. Confirm that ampersand is properly decoded.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
- Fixed `PostPrimaryCategory` component to display decoded HTML entities

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @psorensen

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
