### PR TITLE
Fix: respect `isEditable` context in `PostMeta` component

### DIFF
--- a/components/post-meta/index.tsx
+++ b/components/post-meta/index.tsx
@@ -1,11 +1,14 @@
 import { RichText } from '@wordpress/block-editor';
 import { __experimentalNumberControl as NumberControl, ToggleControl } from '@wordpress/components';
 import type { ToggleControlProps } from '@wordpress/components/src/toggle-control/types';
-import { usePostMetaValue, useIsSupportedMetaField } from '../../hooks';
+import { usePostMetaValue, useIsSupportedMetaField, usePost } from '../../hooks';
 import { toSentence } from './utilities';
 
 interface MetaStringProps
-	extends Omit<React.ComponentPropsWithoutRef<typeof RichText>, 'value' | 'onChange'> {
+	extends Omit<
+		React.ComponentPropsWithoutRef<typeof RichText>,
+		'value' | 'onChange' | 'multiline'
+	> {
 	/**
 	 * The meta key to use.
 	 */
@@ -15,6 +18,11 @@ interface MetaStringProps
 const MetaString: React.FC<MetaStringProps> = (props) => {
 	const { metaKey, tagName = 'p' } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue<string>(metaKey);
+	const { isEditable } = usePost();
+
+	if (!isEditable) {
+		return <RichText.Content value={metaValue ?? ''} tagName={tagName} {...props} />;
+	}
 
 	return (
 		<RichText
@@ -36,11 +44,13 @@ interface MetaNumberProps {
 const MetaNumber: React.FC<MetaNumberProps> = (props) => {
 	const { metaKey } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue<number>(metaKey);
+	const { isEditable } = usePost();
 
 	return (
 		<NumberControl
 			value={metaValue}
 			onChange={(value) => setMetaValue(parseInt(value ?? '', 10))}
+			disabled={!isEditable}
 			{...props}
 		/>
 	);
@@ -56,8 +66,16 @@ interface MetaBooleanProps extends Pick<ToggleControlProps, 'label'> {
 const MetaBoolean: React.FC<MetaBooleanProps> = (props) => {
 	const { metaKey } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue<boolean>(metaKey);
+	const { isEditable } = usePost();
 
-	return <ToggleControl checked={metaValue} onChange={setMetaValue} {...props} />;
+	return (
+		<ToggleControl
+			checked={metaValue}
+			onChange={setMetaValue}
+			disabled={!isEditable}
+			{...props}
+		/>
+	);
 };
 
 interface PostMetaProps {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Respect the `isEditable` context that one can define on the `<PostContext>` component inside the PostMeta component. 

This is to ensure that the meta value isn't editable when editing should be disabled. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Respect `isEditable` context in `PostMeta` component

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @fabiankaegy 
