### PR TITLE
Fix: only spread rest props to child components

### DIFF
--- a/components/post-meta/index.tsx
+++ b/components/post-meta/index.tsx
@@ -16,7 +16,7 @@ interface MetaStringProps
 }
 
 const MetaString: React.FC<MetaStringProps> = (props) => {
-	const { metaKey, tagName = 'p' } = props;
+	const { metaKey, tagName = 'p', ...rest } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue<string>(metaKey);
 	const { isEditable } = usePost();
 
@@ -29,7 +29,7 @@ const MetaString: React.FC<MetaStringProps> = (props) => {
 			value={metaValue ?? ''}
 			onChange={(value: string) => setMetaValue(value)}
 			tagName={tagName}
-			{...props}
+			{...rest}
 		/>
 	);
 };
@@ -42,7 +42,7 @@ interface MetaNumberProps {
 }
 
 const MetaNumber: React.FC<MetaNumberProps> = (props) => {
-	const { metaKey } = props;
+	const { metaKey, ...rest } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue<number>(metaKey);
 	const { isEditable } = usePost();
 
@@ -51,7 +51,7 @@ const MetaNumber: React.FC<MetaNumberProps> = (props) => {
 			value={metaValue}
 			onChange={(value) => setMetaValue(parseInt(value ?? '', 10))}
 			disabled={!isEditable}
-			{...props}
+			{...rest}
 		/>
 	);
 };
@@ -64,7 +64,7 @@ interface MetaBooleanProps extends Pick<ToggleControlProps, 'label'> {
 }
 
 const MetaBoolean: React.FC<MetaBooleanProps> = (props) => {
-	const { metaKey } = props;
+	const { metaKey, ...rest } = props;
 	const [metaValue, setMetaValue] = usePostMetaValue<boolean>(metaKey);
 	const { isEditable } = usePost();
 
@@ -73,7 +73,7 @@ const MetaBoolean: React.FC<MetaBooleanProps> = (props) => {
 			checked={metaValue}
 			onChange={setMetaValue}
 			disabled={!isEditable}
-			{...props}
+			{...rest}
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

In the `PostMeta` components we passed all the `props` down to the individual child components such as `RichText`. However in reality we should have excluded the ones we already deconstructed out. So instead we now only pass the remaining props after we took out the ones we need for other things. 
