### PR TITLE
Fix error thrown by useRequestData hook

### DIFF
--- a/hooks/use-request-data/index.ts
+++ b/hooks/use-request-data/index.ts
@@ -9,7 +9,7 @@ import isObject from 'lodash/isObject';
  */
 import { store as coreStore } from '@wordpress/core-data';
 // @ts-ignore-next-line - The type definitions for the data package are incomplete.
-import { useSelect, useDispatch, store as dataStore } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Hook for retrieving data from the WordPress REST API.
@@ -27,7 +27,7 @@ export const useRequestData = (entity: string, kind: string, query: Record<strin
 			return {
 				// @ts-ignore-next-line - The type definitions for the data package are incomplete.
 				data: select(coreStore)[functionToCall](entity, kind, query),
-				isLoading: select(dataStore).isResolving(coreStore, functionToCall, [
+				isLoading: select('core/data').isResolving(coreStore, functionToCall, [
 					entity,
 					kind,
 					query,


### PR DESCRIPTION
### Description of the Change
The `useRequestData` hook is broken due to pulling in the store name from the `@wordpress/data` package. 
However, it looks like that package [does not export the store](https://github.com/WordPress/gutenberg/blob/1976565419e62a6924d2c73a3ec4b432701200a9/packages/data/src/index.js) as the rest of the other WP packages, hence the hook is breaking as it's trying to use it on line 30 (but not on line 24).

### How to test the Change
Create a block / editor plugin, pull in the `useRequestData` hook and try to use it.
Before these changes, you should get a JS error in the console.
After these changes, the hook should work as expected.

### Changelog Entry
> Fixed - `useRequestData` hook was breaking due to wrong store name

### Credits
Props @theskinnyghost 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
