### PR TITLE
Fix registerBlockExtension apply condition

### DIFF
--- a/api/register-block-extension/index.tsx
+++ b/api/register-block-extension/index.tsx
@@ -39,7 +39,7 @@ function registerBlockExtension(
 	const isMultiBlock = Array.isArray(blockName);
 
 	const shouldApplyBlockExtension = (blockType: string): boolean => {
-		if (blockName === '*') {
+		if (blockName === '*' || blockName === 'all') {
 			return true;
 		}
 


### PR DESCRIPTION
Hey,
apply condition for `*` is failing because `blockName` variable was changed to `all` before `shouldApplyBlockExtension` is called.
This should fix it.

Refers [#345](https://github.com/10up/block-components/issues/345)

### How to test the Change
Using `registerBlockExtension` with `*` is working now.

### Checklist:
- [*] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).

