### PR TITLE
Fix Media Library image preselect when using MediaToolbar

### DIFF
--- a/components/media-toolbar/index.tsx
+++ b/components/media-toolbar/index.tsx
@@ -66,6 +66,7 @@ export const MediaToolbar: React.FC<MediaToolbarProps> = ({
 			{hasImage ? (
 				<>
 					<MediaReplaceFlow
+						mediaId={id}
 						mediaUrl={media?.source_url}
 						onSelect={onSelect}
 						name={mergedLabels.replace}


### PR DESCRIPTION
Hey,
this fixes image preselect in Media Library when using MediaToolbar's "Replace Image".

Before:
![image](https://github.com/user-attachments/assets/0d4873b7-4606-459e-8eb2-c8eb854e62b9)

After:
![image](https://github.com/user-attachments/assets/3ac58cb8-197a-47a9-8ea7-68fa6c498227)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [* ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
