### PR TITLE
Feature: Modernize styling of content picker

### DIFF
--- a/components/content-picker/DraggableChip.tsx
+++ b/components/content-picker/DraggableChip.tsx
@@ -1,4 +1,4 @@
-import { Flex, FlexItem } from '@wordpress/components';
+import { Flex, FlexItem, __experimentalTruncate as Truncate } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import styled from '@emotion/styled';
 import { DragHandle } from '../drag-handle';
@@ -19,6 +19,7 @@ const Chip = styled.div`
 	font-size: 13px;
 	line-height: 1.4;
 	white-space: nowrap;
+	max-width: min(300px, 100%);
 
 	svg {
 		fill: currentColor;
@@ -40,7 +41,9 @@ export const DraggableChip = (props: DraggableChipProps) => {
 		<ChipWrapper>
 			<Chip data-testid="draggable-chip">
 				<Flex justify="center" align="center" gap={4}>
-					<FlexItem>{title}</FlexItem>
+					<FlexItem>
+						<Truncate>{title}</Truncate>
+					</FlexItem>
 					<DragHandle />
 				</Flex>
 			</Chip>

--- a/components/content-picker/DraggableChip.tsx
+++ b/components/content-picker/DraggableChip.tsx
@@ -1,0 +1,45 @@
+import { Flex, FlexItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import styled from '@emotion/styled';
+import { DragHandle } from '../drag-handle';
+
+const ChipWrapper = styled.div`
+	pointer-events: none;
+`;
+
+const Chip = styled.div`
+	background: #1e1e1e;
+	opacity: 0.9;
+	border-radius: 2px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	color: #fff;
+	display: inline-flex;
+	margin: 0;
+	padding: 8px;
+	font-size: 13px;
+	line-height: 1.4;
+	white-space: nowrap;
+
+	svg {
+		fill: currentColor;
+	}
+`;
+
+interface DraggableChipProps {
+	title?: string;
+}
+
+export const DraggableChip = ({
+	title = __('Moving 1 item', '10up-block-components'),
+}: DraggableChipProps) => {
+	return (
+		<ChipWrapper>
+			<Chip data-testid="draggable-chip">
+				<Flex justify="center" align="center" gap={4}>
+					<FlexItem>{title}</FlexItem>
+					<DragHandle />
+				</Flex>
+			</Chip>
+		</ChipWrapper>
+	);
+};

--- a/components/content-picker/DraggableChip.tsx
+++ b/components/content-picker/DraggableChip.tsx
@@ -26,12 +26,16 @@ const Chip = styled.div`
 `;
 
 interface DraggableChipProps {
-	title?: string;
+	title: string;
 }
 
-export const DraggableChip = ({
-	title = __('Moving 1 item', '10up-block-components'),
-}: DraggableChipProps) => {
+export const DraggableChip = (props: DraggableChipProps) => {
+	let { title = __('Moving 1 item', '10up-block-components') } = props;
+
+	if (!title) {
+		title = __('Moving 1 item', '10up-block-components');
+	}
+
 	return (
 		<ChipWrapper>
 			<Chip data-testid="draggable-chip">

--- a/components/content-picker/DraggableChip.tsx
+++ b/components/content-picker/DraggableChip.tsx
@@ -16,7 +16,7 @@ const Chip = styled.div`
 	display: inline-flex;
 	margin: 0;
 	padding: 8px;
-	font-size: 13px;
+	font-size: 0.875rem;
 	line-height: 1.4;
 	white-space: nowrap;
 	max-width: min(300px, 100%);

--- a/components/content-picker/PickedItem.tsx
+++ b/components/content-picker/PickedItem.tsx
@@ -17,7 +17,7 @@ export type PickedItemType = {
 	url: string;
 };
 
-const PickedItemContainer = styled.div<{ isDragging?: boolean }>`
+const PickedItemContainer = styled.div<{ isDragging?: boolean; isOrderable?: boolean }>`
 	position: relative;
 	display: flex;
 	align-items: center;
@@ -29,7 +29,10 @@ const PickedItemContainer = styled.div<{ isDragging?: boolean }>`
 	background: ${({ isDragging }) => (isDragging ? '#f0f0f0' : 'transparent')};
 	border-radius: 2px;
 	transition: background-color 0.1s linear;
-	cursor: ${({ isDragging }) => (isDragging ? 'grabbing' : 'grab')};
+	cursor: ${({ isDragging, isOrderable }) => {
+		if (!isOrderable) return 'default';
+		return isDragging ? 'grabbing' : 'grab';
+	}};
 	touch-action: none;
 
 	&:hover {
@@ -142,6 +145,7 @@ const PickedItem: React.FC<PickedItemProps> = ({
 				{...attributes}
 				{...listeners}
 				isDragging={isDragging}
+				isOrderable={isOrderable}
 			>
 				{isOrderable && (
 					<DragHandleWrapper isDragging={isDragging}>

--- a/components/content-picker/PickedItem.tsx
+++ b/components/content-picker/PickedItem.tsx
@@ -101,14 +101,14 @@ const ItemContent = styled.div`
 `;
 
 const ItemTitle = styled.span`
-	font-size: 13px;
+	font-size: 0.875rem;
 	line-height: 1.4;
 	font-weight: 500;
 	color: #1e1e1e;
 `;
 
 const ItemURL = styled.span`
-	font-size: 12px;
+	font-size: 0.75rem;
 	line-height: 1.4;
 	color: #757575;
 	white-space: nowrap;
@@ -136,6 +136,12 @@ const MoveButton = styled(Button)`
 		opacity: 1;
 		pointer-events: auto;
 	}
+`;
+
+const ButtonContainer = styled.div`
+	display: flex;
+	gap: 4px;
+	margin-left: auto;
 `;
 
 interface PickedItemProps {
@@ -203,50 +209,52 @@ const PickedItem: React.FC<PickedItemProps> = ({
 						<ItemURL>{filterURLForDisplay(safeDecodeURI(item.url)) || ''}</ItemURL>
 					)}
 				</ItemContent>
-				{isOrderable && !isDragging && (
-					<VStack spacing={0} className="move-buttons">
-						<MoveButton
-							disabled={isFirst}
-							icon={chevronUp}
+				<ButtonContainer>
+					{isOrderable && !isDragging && (
+						<VStack spacing={0} className="move-buttons">
+							<MoveButton
+								disabled={isFirst}
+								icon={chevronUp}
+								onClick={(e: React.MouseEvent) => {
+									e.stopPropagation();
+									onMoveUp?.();
+								}}
+								className="move-up-button"
+							>
+								<VisuallyHidden>
+									{__('Move item up', '10up-block-components')}
+								</VisuallyHidden>
+							</MoveButton>
+							<MoveButton
+								disabled={isLast}
+								icon={chevronDown}
+								onClick={(e: React.MouseEvent) => {
+									e.stopPropagation();
+									onMoveDown?.();
+								}}
+								className="move-down-button"
+							>
+								<VisuallyHidden>
+									{__('Move item down', '10up-block-components')}
+								</VisuallyHidden>
+							</MoveButton>
+						</VStack>
+					)}
+					{!isDragging && (
+						<RemoveButton
+							className="remove-button"
+							icon={close}
+							size="small"
+							variant="tertiary"
+							isDestructive
+							label={__('Remove item', '10up-block-components')}
 							onClick={(e: React.MouseEvent) => {
 								e.stopPropagation();
-								onMoveUp?.();
+								handleItemDelete(item);
 							}}
-							className="move-up-button"
-						>
-							<VisuallyHidden>
-								{__('Move item up', '10up-block-components')}
-							</VisuallyHidden>
-						</MoveButton>
-						<MoveButton
-							disabled={isLast}
-							icon={chevronDown}
-							onClick={(e: React.MouseEvent) => {
-								e.stopPropagation();
-								onMoveDown?.();
-							}}
-							className="move-down-button"
-						>
-							<VisuallyHidden>
-								{__('Move item down', '10up-block-components')}
-							</VisuallyHidden>
-						</MoveButton>
-					</VStack>
-				)}
-				{!isDragging && (
-					<RemoveButton
-						className="remove-button"
-						icon={close}
-						size="small"
-						variant="tertiary"
-						isDestructive
-						label={__('Remove item', '10up-block-components')}
-						onClick={(e: React.MouseEvent) => {
-							e.stopPropagation();
-							handleItemDelete(item);
-						}}
-					/>
-				)}
+						/>
+					)}
+				</ButtonContainer>
 			</PickedItemContainer>
 		</TreeGridRow>
 	);

--- a/components/content-picker/PickedItem.tsx
+++ b/components/content-picker/PickedItem.tsx
@@ -140,6 +140,7 @@ const MoveButton = styled(Button)`
 
 const ButtonContainer = styled.div`
 	display: flex;
+	align-items: center;
 	gap: 4px;
 	margin-left: auto;
 `;

--- a/components/content-picker/PickedItem.tsx
+++ b/components/content-picker/PickedItem.tsx
@@ -7,6 +7,8 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { Post, User, store as coreStore } from '@wordpress/core-data';
+import { close } from '@wordpress/icons';
+import { Button, __experimentalTreeGridRow as TreeGridRow } from '@wordpress/components';
 import { DragHandle } from '../drag-handle';
 import { ContentSearchMode } from '../content-search/types';
 
@@ -21,20 +23,6 @@ type Term = {
 	slug: string;
 	taxonomy: string;
 };
-
-const StyledCloseButton = styled('button')`
-	display: block;
-	padding: 2px 8px 6px 8px;
-	margin-left: auto;
-	font-size: 2em;
-	cursor: pointer;
-	border: none;
-	background-color: transparent;
-
-	&:hover {
-		background-color: #ccc;
-	}
-`;
 
 function getEntityKind(mode: ContentSearchMode) {
 	let type;
@@ -61,22 +49,98 @@ export type PickedItemType = {
 	url: string;
 };
 
+const PickedItemContainer = styled.div<{ isDragging?: boolean }>`
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 8px;
+	min-height: 36px;
+	color: #1e1e1e;
+	opacity: ${({ isDragging }) => (isDragging ? 0.5 : 1)};
+	background: ${({ isDragging }) => (isDragging ? '#f0f0f0' : 'transparent')};
+	border-radius: 2px;
+	transition: background-color 0.1s linear;
+	cursor: ${({ isDragging }) => (isDragging ? 'grabbing' : 'grab')};
+	touch-action: none;
+
+	&:hover {
+		background: #f0f0f0;
+	}
+
+	.components-button.has-icon {
+		min-width: 24px;
+		padding: 0;
+		height: 24px;
+	}
+
+	&:not(:hover) .remove-button {
+		opacity: 0;
+		pointer-events: none;
+	}
+`;
+
+const DragHandleWrapper = styled.div<{ isDragging: boolean }>`
+	display: ${({ isDragging }) => (isDragging ? 'flex' : 'none')};
+	align-items: center;
+	justify-content: center;
+	opacity: ${({ isDragging }) => (isDragging ? 1 : 0)};
+	pointer-events: ${({ isDragging }) => (isDragging ? 'auto' : 'none')};
+	transition: opacity 0.1s linear;
+	position: absolute;
+	left: 8px;
+`;
+
+const RemoveButton = styled(Button)<{ isDragging?: boolean }>`
+	opacity: ${({ isDragging }) => (isDragging ? 0 : 1)};
+	pointer-events: ${({ isDragging }) => (isDragging ? 'none' : 'auto')};
+	transition: opacity 0.1s linear;
+
+	&:focus {
+		opacity: 1;
+		pointer-events: auto;
+	}
+`;
+
+const ItemContent = styled.div`
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding-left: ${({ isDragging }: { isDragging?: boolean }) => (isDragging ? '24px' : '0')};
+	transition: padding-left 0.1s linear;
+`;
+
+const ItemTitle = styled.span`
+	font-size: 13px;
+	line-height: 1.4;
+	font-weight: 500;
+	color: #1e1e1e;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+`;
+
+const ItemURL = styled.span`
+	font-size: 12px;
+	line-height: 1.4;
+	color: #757575;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+`;
+
 interface PickedItemProps {
 	item: PickedItemType;
 	isOrderable?: boolean;
 	handleItemDelete: (deletedItem: PickedItemType) => void;
 	mode: ContentSearchMode;
 	id: number | string;
+	isDragging?: boolean;
+	positionInSet?: number;
+	setSize?: number;
 }
-
-const PickedItemContainer = styled.span`
-	&&& {
-		align-items: flex-start;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-	}
-`;
 
 /**
  * PickedItem
@@ -90,10 +154,13 @@ const PickedItem: React.FC<PickedItemProps> = ({
 	handleItemDelete,
 	mode,
 	id,
+	isDragging = false,
+	positionInSet = 1,
+	setSize = 1,
 }) => {
 	const entityKind = getEntityKind(mode);
 
-	const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
+	const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
 		id,
 	});
 
@@ -162,43 +229,50 @@ const PickedItem: React.FC<PickedItemProps> = ({
 	const style = {
 		transform: CSS.Transform.toString(transform),
 		transition,
-		border: isDragging ? '2px dashed #ddd' : '2px dashed transparent',
-		paddingTop: '10px',
-		paddingBottom: '10px',
-		display: 'flex',
-		alignItems: 'center',
-		paddingLeft: isOrderable ? '3px' : '8px',
 	};
-
-	const normalizedItemType = item?.type ? item.type : 'post';
-	const className = `block-editor-link-control__search-item is-entity is-type-${normalizedItemType}`;
 
 	if (!preparedItem) {
 		return null;
 	}
 
 	return (
-		<li className={className} ref={setNodeRef} style={style}>
-			{isOrderable ? <DragHandle {...attributes} {...listeners} /> : ''}
-			<PickedItemContainer className="block-editor-link-control__search-item-header">
-				<span className="block-editor-link-control__search-item-title">
-					{decodeEntities(preparedItem.title)}
-				</span>
-				<span aria-hidden className="block-editor-link-control__search-item-info">
-					{filterURLForDisplay(safeDecodeURI(preparedItem.url)) || ''}
-				</span>
-			</PickedItemContainer>
-
-			<StyledCloseButton
-				type="button"
-				onClick={() => {
-					handleItemDelete(preparedItem);
-				}}
-				aria-label={__('Delete item', '10up-block-components')}
+		<TreeGridRow level={1} positionInSet={positionInSet} setSize={setSize}>
+			<PickedItemContainer
+				ref={setNodeRef}
+				style={style}
+				{...attributes}
+				{...listeners}
+				isDragging={isDragging}
 			>
-				&times;
-			</StyledCloseButton>
-		</li>
+				{isOrderable && (
+					<DragHandleWrapper isDragging={isDragging}>
+						<DragHandle />
+					</DragHandleWrapper>
+				)}
+				<ItemContent isDragging={isDragging}>
+					<ItemTitle>{decodeEntities(preparedItem.title)}</ItemTitle>
+					{preparedItem.url && (
+						<ItemURL>
+							{filterURLForDisplay(safeDecodeURI(preparedItem.url)) || ''}
+						</ItemURL>
+					)}
+				</ItemContent>
+				{!isDragging && (
+					<RemoveButton
+						className="remove-button"
+						icon={close}
+						size="small"
+						variant="tertiary"
+						isDestructive
+						label={__('Remove item', '10up-block-components')}
+						onClick={(e: React.MouseEvent) => {
+							e.stopPropagation();
+							handleItemDelete(item);
+						}}
+					/>
+				)}
+			</PickedItemContainer>
+		</TreeGridRow>
 	);
 };
 

--- a/components/content-picker/SortableList.tsx
+++ b/components/content-picker/SortableList.tsx
@@ -15,6 +15,7 @@ import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
 import { useCallback, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PickedItem, { PickedItemType } from './PickedItem';
+import { DraggableChip } from './DraggableChip';
 import { ContentSearchMode } from '../content-search/types';
 
 const dropAnimation = {
@@ -83,6 +84,8 @@ const SortableList: React.FC<SortableListProps> = ({
 		[activeId, posts],
 	);
 
+	console.log({ activePost });
+
 	if (!hasMultiplePosts && !isOrderable) {
 		return (
 			<>
@@ -132,18 +135,7 @@ const SortableList: React.FC<SortableListProps> = ({
 				</SortableContext>
 			</TreeGrid>
 			<DragOverlay dropAnimation={dropAnimation}>
-				{activeId && activePost ? (
-					<PickedItem
-						isOrderable={hasMultiplePosts && isOrderable}
-						handleItemDelete={handleItemDelete}
-						item={activePost}
-						mode={mode}
-						id={activePost.uuid}
-						isDragging
-						positionInSet={posts.findIndex((post) => post.uuid === activeId) + 1}
-						setSize={posts.length}
-					/>
-				) : null}
+				{activeId && activePost ? <DraggableChip title={activePost.title} /> : null}
 			</DragOverlay>
 		</DndContext>
 	);

--- a/components/content-picker/SortableList.tsx
+++ b/components/content-picker/SortableList.tsx
@@ -167,34 +167,45 @@ const SortableList: React.FC<SortableListProps> = ({
 	}, []);
 
 	const activePost = useMemo(
-		() => preparedItems?.[activeId as string],
+		() => (activeId ? preparedItems?.[activeId as string] : null),
 		[activeId, preparedItems],
 	);
 
-	if (!hasMultiplePosts && !isOrderable) {
-		return (
-			<>
-				{posts.map((post) => {
-					const preparedItem = preparedItems[post.uuid];
-					if (!preparedItem) return null;
+	const renderItems = (items: Array<PickedItemType>) => {
+		return items.map((post, index) => {
+			const preparedItem = preparedItems[post.uuid];
+			if (!preparedItem) return null;
 
-					return (
-						<PickedItem
-							isOrderable={false}
-							key={post.uuid}
-							handleItemDelete={handleItemDelete}
-							item={preparedItem}
-							mode={mode}
-							id={post.uuid}
-							positionInSet={1}
-							setSize={1}
-						/>
-					);
-				})}
-			</>
+			return (
+				<PickedItem
+					isOrderable={hasMultiplePosts && isOrderable}
+					key={post.uuid}
+					handleItemDelete={handleItemDelete}
+					item={preparedItem}
+					mode={mode}
+					id={post.uuid}
+					positionInSet={index + 1}
+					setSize={items.length}
+				/>
+			);
+		});
+	};
+
+	// If not orderable or only one item, render simple list
+	if (!isOrderable || !hasMultiplePosts) {
+		return (
+			<TreeGrid
+				className="block-editor-list-view-tree"
+				aria-label={__('Selected items list')}
+				onCollapseRow={() => {}}
+				onExpandRow={() => {}}
+			>
+				{renderItems(posts)}
+			</TreeGrid>
 		);
 	}
 
+	// If orderable, wrap with drag and drop context
 	return (
 		<DndContext
 			sensors={sensors}
@@ -210,23 +221,7 @@ const SortableList: React.FC<SortableListProps> = ({
 				onExpandRow={() => {}}
 			>
 				<SortableContext items={items} strategy={verticalListSortingStrategy}>
-					{posts.map((post, index) => {
-						const preparedItem = preparedItems[post.uuid];
-						if (!preparedItem) return null;
-
-						return (
-							<PickedItem
-								isOrderable={hasMultiplePosts && isOrderable}
-								key={post.uuid}
-								handleItemDelete={handleItemDelete}
-								item={preparedItem}
-								mode={mode}
-								id={post.uuid}
-								positionInSet={index + 1}
-								setSize={posts.length}
-							/>
-						);
-					})}
+					{renderItems(posts)}
 				</SortableContext>
 			</TreeGrid>
 			<DragOverlay dropAnimation={dropAnimation}>

--- a/components/content-picker/SortableList.tsx
+++ b/components/content-picker/SortableList.tsx
@@ -6,10 +6,21 @@ import {
 	useSensor,
 	useSensors,
 	DragEndEvent,
+	DragStartEvent,
+	DragOverlay,
+	defaultDropAnimation,
 } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { __experimentalTreeGrid as TreeGrid } from '@wordpress/components';
+import { useCallback, useState, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import PickedItem, { PickedItemType } from './PickedItem';
 import { ContentSearchMode } from '../content-search/types';
+
+const dropAnimation = {
+	...defaultDropAnimation,
+	dragSourceOpacity: 0.5,
+};
 
 interface SortableListProps {
 	posts: Array<PickedItemType>;
@@ -27,35 +38,113 @@ const SortableList: React.FC<SortableListProps> = ({
 	setPosts,
 }) => {
 	const hasMultiplePosts = posts.length > 1;
+	const [activeId, setActiveId] = useState<string | null>(null);
 
 	const items = posts.map((item) => item.uuid);
-	const sensors = useSensors(useSensor(MouseSensor), useSensor(TouchSensor));
+	const sensors = useSensors(
+		useSensor(MouseSensor, {
+			activationConstraint: {
+				distance: 5,
+			},
+		}),
+		useSensor(TouchSensor, {
+			activationConstraint: {
+				delay: 250,
+				tolerance: 5,
+			},
+		}),
+	);
 
-	const handleDragEnd = (event: DragEndEvent) => {
-		const { active, over } = event;
+	const handleDragStart = useCallback((event: DragStartEvent) => {
+		setActiveId(event.active.id as string);
+	}, []);
 
-		if (active.id !== over?.id) {
-			const oldIndex = posts.findIndex((post) => post.uuid === active.id);
-			const newIndex = posts.findIndex((post) => post.uuid === over?.id);
+	const handleDragEnd = useCallback(
+		(event: DragEndEvent) => {
+			const { active, over } = event;
+			setActiveId(null);
 
-			setPosts(arrayMove(posts, oldIndex, newIndex));
-		}
-	};
+			if (active.id !== over?.id) {
+				const oldIndex = posts.findIndex((post) => post.uuid === active.id);
+				const newIndex = posts.findIndex((post) => post.uuid === over?.id);
 
-	return (
-		<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-			<SortableContext items={items} strategy={verticalListSortingStrategy}>
+				setPosts(arrayMove(posts, oldIndex, newIndex));
+			}
+		},
+		[posts, setPosts],
+	);
+
+	const handleDragCancel = useCallback(() => {
+		setActiveId(null);
+	}, []);
+
+	const activePost = useMemo(
+		() => posts.find((post) => post.uuid === activeId),
+		[activeId, posts],
+	);
+
+	if (!hasMultiplePosts && !isOrderable) {
+		return (
+			<>
 				{posts.map((post) => (
 					<PickedItem
-						isOrderable={hasMultiplePosts && isOrderable}
+						isOrderable={false}
 						key={post.uuid}
 						handleItemDelete={handleItemDelete}
 						item={post}
 						mode={mode}
 						id={post.uuid}
+						positionInSet={1}
+						setSize={1}
 					/>
 				))}
-			</SortableContext>
+			</>
+		);
+	}
+
+	return (
+		<DndContext
+			sensors={sensors}
+			collisionDetection={closestCenter}
+			onDragStart={handleDragStart}
+			onDragEnd={handleDragEnd}
+			onDragCancel={handleDragCancel}
+		>
+			<TreeGrid
+				className="block-editor-list-view-tree"
+				aria-label={__('Selected items list')}
+				onCollapseRow={() => {}}
+				onExpandRow={() => {}}
+			>
+				<SortableContext items={items} strategy={verticalListSortingStrategy}>
+					{posts.map((post, index) => (
+						<PickedItem
+							isOrderable={hasMultiplePosts && isOrderable}
+							key={post.uuid}
+							handleItemDelete={handleItemDelete}
+							item={post}
+							mode={mode}
+							id={post.uuid}
+							positionInSet={index + 1}
+							setSize={posts.length}
+						/>
+					))}
+				</SortableContext>
+			</TreeGrid>
+			<DragOverlay dropAnimation={dropAnimation}>
+				{activeId && activePost ? (
+					<PickedItem
+						isOrderable={hasMultiplePosts && isOrderable}
+						handleItemDelete={handleItemDelete}
+						item={activePost}
+						mode={mode}
+						id={activePost.uuid}
+						isDragging
+						positionInSet={posts.findIndex((post) => post.uuid === activeId) + 1}
+						setSize={posts.length}
+					/>
+				) : null}
+			</DragOverlay>
 		</DndContext>
 	);
 };

--- a/components/content-picker/SortableList.tsx
+++ b/components/content-picker/SortableList.tsx
@@ -39,7 +39,7 @@ type Term = {
 	description: string;
 	id: number;
 	link: string;
-	meta: { [key: string]: unknown };
+	meta: Record<string, unknown>;
 	name: string;
 	parent: number;
 	slug: string;

--- a/components/content-picker/SortableList.tsx
+++ b/components/content-picker/SortableList.tsx
@@ -16,6 +16,7 @@ import { useCallback, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { Post, User, store as coreStore } from '@wordpress/core-data';
+import styled from '@emotion/styled';
 import PickedItem, { PickedItemType } from './PickedItem';
 import { DraggableChip } from './DraggableChip';
 import { ContentSearchMode } from '../content-search/types';
@@ -61,6 +62,19 @@ function getEntityKind(mode: ContentSearchMode) {
 
 	return type;
 }
+
+const StyledTreeGrid = styled(TreeGrid)`
+	max-width: 100%;
+	display: block;
+
+	& tbody,
+	& tr,
+	& td {
+		display: block;
+		max-width: 100%;
+		width: 100%;
+	}
+`;
 
 const SortableList: React.FC<SortableListProps> = ({
 	posts,
@@ -176,6 +190,16 @@ const SortableList: React.FC<SortableListProps> = ({
 			const preparedItem = preparedItems[post.uuid];
 			if (!preparedItem) return null;
 
+			const handleMoveUp = () => {
+				if (index === 0) return;
+				setPosts(arrayMove(posts, index, index - 1));
+			};
+
+			const handleMoveDown = () => {
+				if (index === items.length - 1) return;
+				setPosts(arrayMove(posts, index, index + 1));
+			};
+
 			return (
 				<PickedItem
 					isOrderable={hasMultiplePosts && isOrderable}
@@ -186,6 +210,8 @@ const SortableList: React.FC<SortableListProps> = ({
 					id={post.uuid}
 					positionInSet={index + 1}
 					setSize={items.length}
+					onMoveUp={handleMoveUp}
+					onMoveDown={handleMoveDown}
 				/>
 			);
 		});
@@ -194,14 +220,14 @@ const SortableList: React.FC<SortableListProps> = ({
 	// If not orderable or only one item, render simple list
 	if (!isOrderable || !hasMultiplePosts) {
 		return (
-			<TreeGrid
+			<StyledTreeGrid
 				className="block-editor-list-view-tree"
 				aria-label={__('Selected items list')}
 				onCollapseRow={() => {}}
 				onExpandRow={() => {}}
 			>
 				{renderItems(posts)}
-			</TreeGrid>
+			</StyledTreeGrid>
 		);
 	}
 
@@ -214,7 +240,7 @@ const SortableList: React.FC<SortableListProps> = ({
 			onDragEnd={handleDragEnd}
 			onDragCancel={handleDragCancel}
 		>
-			<TreeGrid
+			<StyledTreeGrid
 				className="block-editor-list-view-tree"
 				aria-label={__('Selected items list')}
 				onCollapseRow={() => {}}
@@ -223,7 +249,7 @@ const SortableList: React.FC<SortableListProps> = ({
 				<SortableContext items={items} strategy={verticalListSortingStrategy}>
 					{renderItems(posts)}
 				</SortableContext>
-			</TreeGrid>
+			</StyledTreeGrid>
 			<DragOverlay dropAnimation={dropAnimation}>
 				{activeId && activePost ? <DraggableChip title={activePost.title} /> : null}
 			</DragOverlay>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@10up/block-components",
-	"version": "1.19.4",
+	"version": "1.19.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@10up/block-components",
-			"version": "1.19.4",
+			"version": "1.19.5",
 			"license": "GPL-2.0-or-later",
 			"workspaces": [
 				"./",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@10up/block-components",
-	"version": "1.19.5",
+	"version": "1.19.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@10up/block-components",
-			"version": "1.19.5",
+			"version": "1.19.6",
 			"license": "GPL-2.0-or-later",
 			"workspaces": [
 				"./",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "1.19.4",
+	"version": "1.19.5",
 	"description": "10up Components built for the WordPress Block Editor.",
 	"main": "./dist/index.js",
 	"source": "index.ts",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 		"build-test-env": "npm run build --workspaces --if-present",
 		"start-test-env": "npm run start-env -w example/ && npm run import-media -w example/",
 		"test:e2e": "cypress open",
-		"prepublishOnly": "npm run build",
 		"cypress:open": "cypress open --config-file ./cypress.config.js --e2e --browser chrome",
 		"cypress:run": "cypress run --config-file ./cypress.config.js"
 	},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "1.19.5",
+	"version": "1.19.6",
 	"description": "10up Components built for the WordPress Block Editor.",
 	"main": "./dist/index.js",
 	"source": "index.ts",


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

For a while now the sortable list of selected posts of the content picker has felt a bit out of place in the WP admin. This PR aims to improve it visually.

**Before:** 

https://github.com/user-attachments/assets/8810c724-479a-4cc6-929f-262703f20f78

**After:**


https://github.com/user-attachments/assets/150accfe-6555-4e85-a66e-bcd2c44e4fff

