### PR TITLE
Fix: properly pass abort signal of `useInfiniteQuery` to `apiFetch`

### DIFF
--- a/components/content-search/index.tsx
+++ b/components/content-search/index.tsx
@@ -121,7 +121,7 @@ const ContentSearch: React.FC<ContentSearchProps> = ({
 	const { status, data, error, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage } =
 		useInfiniteQuery({
 			queryKey: ['search', searchString, contentTypes.join(','), mode, perPage, queryFilter],
-			queryFn: async ({ pageParam = 1 }) =>
+			queryFn: async ({ pageParam = 1, signal }) =>
 				fetchSearchResults({
 					keyword: searchString,
 					page: pageParam,
@@ -130,6 +130,7 @@ const ContentSearch: React.FC<ContentSearchProps> = ({
 					contentTypes,
 					queryFilter,
 					excludeItems,
+					signal,
 				}),
 			getNextPageParam: (lastPage) => lastPage.nextPage,
 			getPreviousPageParam: (firstPage) => firstPage.previousPage,

--- a/components/content-search/utils.ts
+++ b/components/content-search/utils.ts
@@ -132,6 +132,7 @@ interface FetchSearchResultsArgs {
 	contentTypes: Array<string>;
 	queryFilter: QueryFilter;
 	excludeItems: Array<IdentifiableObject>;
+	signal?: AbortSignal;
 }
 
 export async function fetchSearchResults({
@@ -142,6 +143,7 @@ export async function fetchSearchResults({
 	contentTypes,
 	queryFilter,
 	excludeItems,
+	signal,
 }: FetchSearchResultsArgs) {
 	const searchQueryString = prepareSearchQuery({
 		keyword,
@@ -154,6 +156,7 @@ export async function fetchSearchResults({
 	const response = await apiFetch<Response>({
 		path: searchQueryString,
 		parse: false,
+		signal,
 	});
 
 	const totalPages = parseInt(


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Properly pass the abort signal from the `useInfiniteQuery` to `apiFetch` in our custom queryFn
