### PR TITLE
Add title attribute for very long titles

### DIFF
--- a/components/content-picker/PickedItem.tsx
+++ b/components/content-picker/PickedItem.tsx
@@ -168,10 +168,13 @@ interface PickedItemProps {
  * @returns {*} React JSX
  */
 const PickedItemPreview: React.FC<{ item: PickedItemType }> = ({ item }) => {
+	const decodedTitle = decodeEntities(item.title);
 	return (
 		<>
 			<ItemTitle>
-				<Truncate>{decodeEntities(item.title)}</Truncate>
+				<Truncate title={decodedTitle} aria-label={decodedTitle}>
+					{decodedTitle}
+				</Truncate>
 			</ItemTitle>
 			{item.url && <ItemURL>{filterURLForDisplay(safeDecodeURI(item.url)) || ''}</ItemURL>}
 		</>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR adds a title attribute to the Truncate component, which solves an issue where posts with very long titles would look identical after truncation.

Now when you hover over a truncated title, you'll see the full text in a tooltip, making it easier to distinguish between similar-looking truncated content.

Related to feedback from: https://github.com/10up/wp-content-connect/pull/94#issuecomment-2855579845

<img width="292" alt="Screenshot 2025-05-16 at 16 05 24" src="https://github.com/user-attachments/assets/71d025dd-d93e-4b61-96e9-8b35cdb3b37a" />


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Title attribute to the PickedItem Truncate component.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @s3rgiosan

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
