### PR TITLE
Fix: use 10up-toolkit for building the example plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vscode
 /dist
 /cypress/videos
+/example/dist

--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,8 @@
 	"description": "Example plugin to show the Content Picker in usage.",
 	"main": "index.js",
 	"scripts": {
-		"build": "npm run clean-dist && wp-scripts build",
-		"start": "wp-scripts start",
+		"build": "npm run clean-dist && 10up-toolkit build",
+		"start": "10up-toolkit start",
 		"wp-env": "wp-env",
 		"clean-dist": "rm -rf ./dist",
 		"start-env": "wp-env start",
@@ -21,11 +21,20 @@
 		"@wordpress/core-data": "^6.28.9",
 		"@wordpress/data": "^9.21.1",
 		"@wordpress/env": "^9.9.0",
-		"@wordpress/eslint-plugin": "^18.0.0",
-		"@wordpress/scripts": "^27.8.0"
+		"10up-toolkit": "^6.4.1"
 	},
 	"dependencies": {
 		"@10up/block-components": "file:../dist/index.js",
 		"@wordpress/icons": "^9.48.0"
+	},
+	"10up-toolkit": {
+		"useBlockAssets": true,
+		"useScriptModules": true,
+		"entry": {
+			"index": "./src/index.js"
+		},
+		"paths": {
+			"blocksDir": "./src/blocks"
+		}
 	}
 }

--- a/example/plugin.php
+++ b/example/plugin.php
@@ -17,11 +17,11 @@ namespace HelloWorld;
 // Useful global constants.
 define( 'EXAMPLE_PLUGIN_TEMPLATE_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXAMPLE_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
-define( 'EXAMPLE_PLUGIN_DIST_PATH', EXAMPLE_PLUGIN_PATH . 'build/' );
-define( 'EXAMPLE_PLUGIN_DIST_URL', EXAMPLE_PLUGIN_TEMPLATE_URL . '/build/' );
+define( 'EXAMPLE_PLUGIN_DIST_PATH', EXAMPLE_PLUGIN_PATH . 'dist/' );
+define( 'EXAMPLE_PLUGIN_DIST_URL', EXAMPLE_PLUGIN_TEMPLATE_URL . '/dist/' );
 define( 'EXAMPLE_PLUGIN_INC', EXAMPLE_PLUGIN_PATH . 'includes/' );
 define( 'EXAMPLE_PLUGIN_BLOCK_DIR', EXAMPLE_PLUGIN_INC . 'blocks/' );
-define( 'EXAMPLE_PLUGIN_BLOCK_DIST_DIR', EXAMPLE_PLUGIN_PATH . 'build/blocks/' );
+define( 'EXAMPLE_PLUGIN_BLOCK_DIST_DIR', EXAMPLE_PLUGIN_PATH . 'dist/blocks/' );
 
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 /**
@@ -44,11 +44,11 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\enqueue_block_editor_scrip
  * Enqueue Block Editor Scripts
  */
 function enqueue_block_editor_scripts() {
-	$asset_file = include EXAMPLE_PLUGIN_DIST_PATH . 'index.asset.php';
+	$asset_file = include EXAMPLE_PLUGIN_DIST_PATH . 'js/index.asset.php';
 
 	wp_enqueue_script(
 		'example-block-editor-script',
-		EXAMPLE_PLUGIN_DIST_URL . 'index.js',
+		EXAMPLE_PLUGIN_DIST_URL . 'js/index.js',
 		$asset_file['dependencies'],
 		$asset_file['version'],
 		true

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,9 +1,0 @@
-const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
-
-module.exports = {
-	...defaultConfig,
-	entry: {
-		...defaultConfig.entry(),
-		'index': './src/index.js',
-	},
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
 				"@wordpress/data": "^9.28.0",
 				"@wordpress/dependency-extraction-webpack-plugin": "^5.8.0",
 				"@wordpress/element": "^5.35.0",
-				"10up-toolkit": "^6.2.0",
+				"10up-toolkit": "^6.4.1",
 				"classnames": "^2.5.1",
 				"cypress": "^13.8.1",
 				"cypress-localstorage-commands": "^2.2.5"
@@ -63,8 +63,7 @@
 				"@wordpress/core-data": "^6.28.9",
 				"@wordpress/data": "^9.21.1",
 				"@wordpress/env": "^9.9.0",
-				"@wordpress/eslint-plugin": "^18.0.0",
-				"@wordpress/scripts": "^27.8.0"
+				"10up-toolkit": "^6.4.1"
 			}
 		},
 		"example/node_modules/@10up/block-components": {
@@ -299,48 +298,6 @@
 				"node": ">=12"
 			}
 		},
-		"example/node_modules/@wordpress/eslint-plugin": {
-			"version": "18.1.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/eslint-parser": "^7.16.0",
-				"@typescript-eslint/eslint-plugin": "^6.4.1",
-				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^7.42.0",
-				"@wordpress/prettier-config": "^3.15.0",
-				"cosmiconfig": "^7.0.0",
-				"eslint-config-prettier": "^8.3.0",
-				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.2.3",
-				"eslint-plugin-jsdoc": "^46.4.6",
-				"eslint-plugin-jsx-a11y": "^6.5.1",
-				"eslint-plugin-playwright": "^0.15.3",
-				"eslint-plugin-prettier": "^5.0.0",
-				"eslint-plugin-react": "^7.27.0",
-				"eslint-plugin-react-hooks": "^4.3.0",
-				"globals": "^13.12.0",
-				"requireindex": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=14",
-				"npm": ">=6.14.4"
-			},
-			"peerDependencies": {
-				"@babel/core": ">=7",
-				"eslint": ">=8",
-				"prettier": ">=3",
-				"typescript": ">=4"
-			},
-			"peerDependenciesMeta": {
-				"prettier": {
-					"optional": true
-				},
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"example/node_modules/@wordpress/icons": {
 			"version": "9.49.0",
 			"license": "GPL-2.0-or-later",
@@ -353,41 +310,10 @@
 				"node": ">=12"
 			}
 		},
-		"example/node_modules/eslint-config-prettier": {
-			"version": "8.10.0",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"eslint-config-prettier": "bin/cli.js"
-			},
-			"peerDependencies": {
-				"eslint": ">=7.0.0"
-			}
-		},
-		"example/node_modules/eslint-plugin-jsdoc": {
-			"version": "46.10.1",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.41.0",
-				"are-docs-informative": "^0.0.2",
-				"comment-parser": "1.4.1",
-				"debug": "^4.3.4",
-				"escape-string-regexp": "^4.0.0",
-				"esquery": "^1.5.0",
-				"is-builtin-module": "^3.2.1",
-				"semver": "^7.5.4",
-				"spdx-expression-parse": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
-			}
-		},
 		"node_modules/@10up/babel-preset-default": {
-			"version": "2.1.1",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@10up/babel-preset-default/-/babel-preset-default-2.1.2.tgz",
+			"integrity": "sha512-HapG7JTmk6CG0iOGxvw4bVL6M0TcZHW5Ck6nm+bz4AahnOwh87rF3+LUtWs1Nzw6Vlu6zbJoRUflt1GPcQ14/Q==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -416,15 +342,17 @@
 			}
 		},
 		"node_modules/@10up/eslint-config": {
-			"version": "4.1.0",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@10up/eslint-config/-/eslint-config-4.1.2.tgz",
+			"integrity": "sha512-csIOSPxWUi30NxUkwhLTxRnEp2o6n+8/uNdfb7+n8c3GDI7HfOozaQcrIWx163U7XDfLQ/dAi1P9QkMp2xCLog==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"peer": true,
 			"dependencies": {
-				"@10up/babel-preset-default": "^2.1.1"
+				"@10up/babel-preset-default": "^2.1.2"
 			},
 			"engines": {
-				"node": "^16 || >=18"
+				"node": ">=16"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.23.7",
@@ -435,7 +363,7 @@
 				"eslint-config-airbnb-base": "^15.0.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-import": "^2.29.1",
-				"eslint-plugin-jest": "^27.6.1",
+				"eslint-plugin-jest": ">=27.6.1",
 				"eslint-plugin-jsdoc": "^48.0.2",
 				"eslint-plugin-jsx-a11y": "^6.8.0",
 				"eslint-plugin-prettier": "^5.1.2",
@@ -3601,6 +3529,431 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
+			"integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
+			"integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
+			"integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
+			"integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
+			"integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
+			"integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
+			"integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
+			"integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
+			"integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
+			"integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
+			"integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
+			"integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
+			"integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
+			"integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
+			"integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
+			"integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
+			"integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
+			"integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
+			"integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
+			"integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
+			"integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
+			"integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
+			"integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
+			"integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
+			"integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"license": "MIT",
@@ -3634,6 +3987,7 @@
 		"node_modules/@eslint/eslintrc": {
 			"version": "2.1.4",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -3654,11 +4008,13 @@
 		},
 		"node_modules/@eslint/eslintrc/node_modules/argparse": {
 			"version": "2.0.1",
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3667,6 +4023,7 @@
 		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
 			"version": "4.1.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -3677,6 +4034,7 @@
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
 			"version": "3.1.2",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3687,6 +4045,7 @@
 		"node_modules/@eslint/js": {
 			"version": "8.57.0",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -3722,22 +4081,10 @@
 			"version": "0.2.2",
 			"license": "MIT"
 		},
-		"node_modules/@hapi/hoek": {
-			"version": "9.3.0",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@hapi/topo": {
-			"version": "5.1.0",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^9.0.0"
-			}
-		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.14",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^2.0.2",
 				"debug": "^4.3.1",
@@ -3750,6 +4097,7 @@
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3758,6 +4106,7 @@
 		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
 			"version": "3.1.2",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -3768,6 +4117,7 @@
 		"node_modules/@humanwhocodes/module-importer": {
 			"version": "1.0.1",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -3778,7 +4128,8 @@
 		},
 		"node_modules/@humanwhocodes/object-schema": {
 			"version": "2.0.3",
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -4527,21 +4878,6 @@
 				"url": "https://opencollective.com/unts"
 			}
 		},
-		"node_modules/@playwright/test": {
-			"version": "1.44.1",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"playwright": "1.44.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
 			"version": "0.5.15",
 			"dev": true,
@@ -4601,106 +4937,6 @@
 			"version": "1.0.0-next.25",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@puppeteer/browsers": {
-			"version": "1.4.6",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"debug": "4.3.4",
-				"extract-zip": "2.0.1",
-				"progress": "2.0.3",
-				"proxy-agent": "6.3.0",
-				"tar-fs": "3.0.4",
-				"unbzip2-stream": "1.4.3",
-				"yargs": "17.7.1"
-			},
-			"bin": {
-				"browsers": "lib/cjs/main-cli.js"
-			},
-			"engines": {
-				"node": ">=16.3.0"
-			},
-			"peerDependencies": {
-				"typescript": ">= 4.7.4"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/debug": {
-			"version": "4.3.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/extract-zip": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/tar-fs": {
-			"version": "3.0.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^3.1.5"
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/tar-stream": {
-			"version": "3.1.7",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"b4a": "^1.6.4",
-				"fast-fifo": "^1.2.0",
-				"streamx": "^2.15.0"
-			}
-		},
-		"node_modules/@puppeteer/browsers/node_modules/yargs": {
-			"version": "17.7.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/@radix-ui/primitive": {
 			"version": "1.0.0",
@@ -4970,128 +5206,6 @@
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
-		},
-		"node_modules/@sentry/core": {
-			"version": "6.19.7",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sentry/hub": "6.19.7",
-				"@sentry/minimal": "6.19.7",
-				"@sentry/types": "6.19.7",
-				"@sentry/utils": "6.19.7",
-				"tslib": "^1.9.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@sentry/core/node_modules/tslib": {
-			"version": "1.14.1",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/@sentry/hub": {
-			"version": "6.19.7",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sentry/types": "6.19.7",
-				"@sentry/utils": "6.19.7",
-				"tslib": "^1.9.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@sentry/hub/node_modules/tslib": {
-			"version": "1.14.1",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/@sentry/minimal": {
-			"version": "6.19.7",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sentry/hub": "6.19.7",
-				"@sentry/types": "6.19.7",
-				"tslib": "^1.9.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@sentry/minimal/node_modules/tslib": {
-			"version": "1.14.1",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/@sentry/node": {
-			"version": "6.19.7",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sentry/core": "6.19.7",
-				"@sentry/hub": "6.19.7",
-				"@sentry/types": "6.19.7",
-				"@sentry/utils": "6.19.7",
-				"cookie": "^0.4.1",
-				"https-proxy-agent": "^5.0.0",
-				"lru_map": "^0.3.3",
-				"tslib": "^1.9.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@sentry/node/node_modules/tslib": {
-			"version": "1.14.1",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/@sentry/types": {
-			"version": "6.19.7",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@sentry/utils": {
-			"version": "6.19.7",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sentry/types": "6.19.7",
-				"tslib": "^1.9.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@sentry/utils/node_modules/tslib": {
-			"version": "1.14.1",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/@sideway/address": {
-			"version": "4.1.5",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^9.0.0"
-			}
-		},
-		"node_modules/@sideway/formula": {
-			"version": "3.0.1",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@sideway/pinpoint": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
@@ -5512,19 +5626,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@tootallnate/once": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@tootallnate/quickjs-emscripten": {
-			"version": "0.23.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@trysound/sax": {
 			"version": "0.2.0",
 			"dev": true,
@@ -5660,15 +5761,6 @@
 				"@types/send": "*"
 			}
 		},
-		"node_modules/@types/glob": {
-			"version": "7.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/minimatch": "*",
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.9",
 			"dev": true,
@@ -5740,16 +5832,6 @@
 				"pretty-format": "^29.0.0"
 			}
 		},
-		"node_modules/@types/jsdom": {
-			"version": "20.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"@types/tough-cookie": "*",
-				"parse5": "^7.0.0"
-			}
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"dev": true,
@@ -5779,15 +5861,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/minimatch": {
-			"version": "5.1.2",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/minimist": {
 			"version": "1.2.5",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/mousetrap": {
 			"version": "1.6.15",
@@ -5930,7 +6008,9 @@
 		"node_modules/@types/source-list-map": {
 			"version": "0.1.6",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
@@ -5940,17 +6020,16 @@
 		"node_modules/@types/tapable": {
 			"version": "1.0.12",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/tough-cookie": {
-			"version": "4.0.5",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@types/uglify-js": {
 			"version": "3.17.5",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"source-map": "^0.6.1"
 			}
@@ -5959,6 +6038,8 @@
 			"version": "0.6.1",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5973,6 +6054,8 @@
 			"version": "4.41.38",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"@types/tapable": "^1",
@@ -5986,6 +6069,8 @@
 			"version": "3.2.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"@types/source-list-map": "*",
@@ -5996,6 +6081,8 @@
 			"version": "0.7.4",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -6004,6 +6091,8 @@
 			"version": "0.6.1",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6483,7 +6572,8 @@
 		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.2.0",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/@use-gesture/core": {
 			"version": "10.3.1",
@@ -6499,6 +6589,135 @@
 			},
 			"peerDependencies": {
 				"react": ">= 16.8.0"
+			}
+		},
+		"node_modules/@vanilla-extract/babel-plugin-debug-ids": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@vanilla-extract/babel-plugin-debug-ids/-/babel-plugin-debug-ids-1.2.0.tgz",
+			"integrity": "sha512-z5nx2QBnOhvmlmBKeRX5sPVLz437wV30u+GJL+Hzj1rGiJYVNvgIIlzUpRNjVQ0MgAgiQIqIUbqPnmMc6HmDlQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.23.9"
+			}
+		},
+		"node_modules/@vanilla-extract/css": {
+			"version": "1.17.2",
+			"resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.17.2.tgz",
+			"integrity": "sha512-gowpfR1zJSplDO7NkGf2Vnw9v9eG1P3aUlQpxa1pOjcknbgWw7UPzIboB6vGJZmoUvDZRFmipss3/Q+RRfhloQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/hash": "^0.9.0",
+				"@vanilla-extract/private": "^1.0.7",
+				"css-what": "^6.1.0",
+				"cssesc": "^3.0.0",
+				"csstype": "^3.0.7",
+				"dedent": "^1.5.3",
+				"deep-object-diff": "^1.1.9",
+				"deepmerge": "^4.2.2",
+				"lru-cache": "^10.4.3",
+				"media-query-parser": "^2.0.2",
+				"modern-ahocorasick": "^1.0.0",
+				"picocolors": "^1.0.0"
+			}
+		},
+		"node_modules/@vanilla-extract/css/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@vanilla-extract/integration": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@vanilla-extract/integration/-/integration-8.0.2.tgz",
+			"integrity": "sha512-w9OvWwsYkqyuyHf9NLnOJ8ap0FGTy2pAeWftgxAEkKE3tF1aYeyEtYRHKxfVH6JRgi8JIeQqELHGMSwz+BxwiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.23.9",
+				"@babel/plugin-syntax-typescript": "^7.23.3",
+				"@vanilla-extract/babel-plugin-debug-ids": "^1.2.0",
+				"@vanilla-extract/css": "^1.17.2",
+				"dedent": "^1.5.3",
+				"esbuild": "npm:esbuild@>=0.17.6 <0.26.0",
+				"eval": "0.1.8",
+				"find-up": "^5.0.0",
+				"javascript-stringify": "^2.0.1",
+				"mlly": "^1.4.2"
+			}
+		},
+		"node_modules/@vanilla-extract/integration/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@vanilla-extract/integration/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@vanilla-extract/integration/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@vanilla-extract/private": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.7.tgz",
+			"integrity": "sha512-v9Yb0bZ5H5Kr8ciwPXyEToOFD7J/fKKH93BYP7NCSZg02VYsA/pNFrLeVDJM2OO/vsygduPKuiEI6ORGQ4IcBw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vanilla-extract/webpack-plugin": {
+			"version": "2.3.19",
+			"resolved": "https://registry.npmjs.org/@vanilla-extract/webpack-plugin/-/webpack-plugin-2.3.19.tgz",
+			"integrity": "sha512-GDphiVib3EMeNkMNyzc7zOs35lBs1GzlALi93dawl/V4e6CsCsGKBNrPzGpDSFvzf4Vq51MNuUkyzwAdfbayPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vanilla-extract/integration": "^8.0.2",
+				"debug": "^4.3.1",
+				"loader-utils": "^2.0.0",
+				"picocolors": "^1.0.0"
+			},
+			"peerDependencies": {
+				"webpack": "^4.30.0 || ^5.20.2"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -6632,47 +6851,6 @@
 				"@xtuc/long": "4.2.2"
 			}
 		},
-		"node_modules/@webpack-cli/configtest": {
-			"version": "2.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.15.0"
-			},
-			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
-			}
-		},
-		"node_modules/@webpack-cli/info": {
-			"version": "2.0.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.15.0"
-			},
-			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
-			}
-		},
-		"node_modules/@webpack-cli/serve": {
-			"version": "2.0.5",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.15.0"
-			},
-			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
-			},
-			"peerDependenciesMeta": {
-				"webpack-dev-server": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wordpress/a11y": {
 			"version": "3.58.0",
 			"dev": true,
@@ -6742,11 +6920,6 @@
 			"engines": {
 				"node": ">=14"
 			}
-		},
-		"node_modules/@wordpress/base-styles": {
-			"version": "4.49.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later"
 		},
 		"node_modules/@wordpress/blob": {
 			"version": "3.58.0",
@@ -8301,28 +8474,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "0.26.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/api-fetch": "^6.55.0",
-				"@wordpress/keycodes": "^3.58.0",
-				"@wordpress/url": "^3.59.0",
-				"change-case": "^4.1.2",
-				"form-data": "^4.0.0",
-				"get-port": "^5.1.1",
-				"lighthouse": "^10.4.0",
-				"mime": "^3.0.0",
-				"web-vitals": "^3.5.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"@playwright/test": ">=1"
-			}
-		},
 		"node_modules/@wordpress/element": {
 			"version": "5.35.0",
 			"license": "GPL-2.0-or-later",
@@ -8438,6 +8589,8 @@
 		},
 		"node_modules/@wordpress/eslint-plugin": {
 			"version": "17.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.13.0.tgz",
+			"integrity": "sha512-QnG5HmOd+XsweKOvrqbOugm9rINUjcsh1jo2SN4cbbTWZJ6nPmcfLS0YJdrKkgOQUnKDPQgBPVEyI8tp19OtBw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -8480,6 +8633,8 @@
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/eslint-config-prettier": {
 			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+			"integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -8491,6 +8646,8 @@
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsdoc": {
 			"version": "46.10.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
+			"integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -8633,22 +8790,6 @@
 				"jest": ">=29"
 			}
 		},
-		"node_modules/@wordpress/jest-preset-default": {
-			"version": "11.29.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/jest-console": "^7.29.0",
-				"babel-jest": "^29.6.2"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@babel/core": ">=7",
-				"jest": ">=29"
-			}
-		},
 		"node_modules/@wordpress/keyboard-shortcuts": {
 			"version": "4.35.0",
 			"dev": true,
@@ -8692,32 +8833,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "4.43.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"npm-package-json-lint": ">=6.0.0"
-			}
-		},
-		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "4.42.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/base-styles": "^4.49.0",
-				"autoprefixer": "^10.2.5"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"postcss": "^8.0.0"
 			}
 		},
 		"node_modules/@wordpress/preferences": {
@@ -8938,416 +9053,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"node_modules/@wordpress/scripts": {
-			"version": "27.9.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/core": "^7.16.0",
-				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
-				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^7.42.0",
-				"@wordpress/browserslist-config": "^5.41.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
-				"@wordpress/e2e-test-utils-playwright": "^0.26.0",
-				"@wordpress/eslint-plugin": "^18.1.0",
-				"@wordpress/jest-preset-default": "^11.29.0",
-				"@wordpress/npm-package-json-lint-config": "^4.43.0",
-				"@wordpress/postcss-plugins-preset": "^4.42.0",
-				"@wordpress/prettier-config": "^3.15.0",
-				"@wordpress/stylelint-config": "^21.41.0",
-				"adm-zip": "^0.5.9",
-				"babel-jest": "^29.6.2",
-				"babel-loader": "^8.2.3",
-				"browserslist": "^4.21.10",
-				"chalk": "^4.0.0",
-				"check-node-version": "^4.1.0",
-				"clean-webpack-plugin": "^3.0.0",
-				"copy-webpack-plugin": "^10.2.0",
-				"cross-spawn": "^5.1.0",
-				"css-loader": "^6.2.0",
-				"cssnano": "^6.0.1",
-				"cwd": "^0.10.0",
-				"dir-glob": "^3.0.1",
-				"eslint": "^8.3.0",
-				"expect-puppeteer": "^4.4.0",
-				"fast-glob": "^3.2.7",
-				"filenamify": "^4.2.0",
-				"jest": "^29.6.2",
-				"jest-dev-server": "^9.0.1",
-				"jest-environment-jsdom": "^29.6.2",
-				"jest-environment-node": "^29.6.2",
-				"markdownlint-cli": "^0.31.1",
-				"merge-deep": "^3.0.3",
-				"mini-css-extract-plugin": "^2.5.1",
-				"minimist": "^1.2.0",
-				"npm-package-json-lint": "^6.4.0",
-				"npm-packlist": "^3.0.0",
-				"postcss": "^8.4.5",
-				"postcss-loader": "^6.2.1",
-				"prettier": "npm:wp-prettier@3.0.3",
-				"puppeteer-core": "^13.2.0",
-				"react-refresh": "^0.14.0",
-				"read-pkg-up": "^7.0.1",
-				"resolve-bin": "^0.4.0",
-				"rtlcss-webpack-plugin": "^4.0.7",
-				"sass": "^1.35.2",
-				"sass-loader": "^12.1.0",
-				"source-map-loader": "^3.0.0",
-				"stylelint": "^14.2.0",
-				"terser-webpack-plugin": "^5.3.9",
-				"url-loader": "^4.1.1",
-				"webpack": "^5.88.2",
-				"webpack-bundle-analyzer": "^4.9.1",
-				"webpack-cli": "^5.1.4",
-				"webpack-dev-server": "^4.15.1"
-			},
-			"bin": {
-				"wp-scripts": "bin/wp-scripts.js"
-			},
-			"engines": {
-				"node": ">=18",
-				"npm": ">=6.14.4"
-			},
-			"peerDependencies": {
-				"@playwright/test": "^1.43.0",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@csstools/selector-specificity": {
-			"version": "2.2.0",
-			"dev": true,
-			"license": "CC0-1.0",
-			"engines": {
-				"node": "^14 || ^16 || >=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^6.0.10"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {
-			"version": "18.1.0",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/eslint-parser": "^7.16.0",
-				"@typescript-eslint/eslint-plugin": "^6.4.1",
-				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^7.42.0",
-				"@wordpress/prettier-config": "^3.15.0",
-				"cosmiconfig": "^7.0.0",
-				"eslint-config-prettier": "^8.3.0",
-				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.2.3",
-				"eslint-plugin-jsdoc": "^46.4.6",
-				"eslint-plugin-jsx-a11y": "^6.5.1",
-				"eslint-plugin-playwright": "^0.15.3",
-				"eslint-plugin-prettier": "^5.0.0",
-				"eslint-plugin-react": "^7.27.0",
-				"eslint-plugin-react-hooks": "^4.3.0",
-				"globals": "^13.12.0",
-				"requireindex": "^1.2.0"
-			},
-			"engines": {
-				"node": ">=14",
-				"npm": ">=6.14.4"
-			},
-			"peerDependencies": {
-				"@babel/core": ">=7",
-				"eslint": ">=8",
-				"prettier": ">=3",
-				"typescript": ">=4"
-			},
-			"peerDependenciesMeta": {
-				"prettier": {
-					"optional": true
-				},
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-config-prettier": {
-			"version": "8.10.0",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"eslint-config-prettier": "bin/cli.js"
-			},
-			"peerDependencies": {
-				"eslint": ">=7.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jsdoc": {
-			"version": "46.10.1",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.41.0",
-				"are-docs-informative": "^0.0.2",
-				"comment-parser": "1.4.1",
-				"debug": "^4.3.4",
-				"escape-string-regexp": "^4.0.0",
-				"esquery": "^1.5.0",
-				"is-builtin-module": "^3.2.1",
-				"semver": "^7.5.4",
-				"spdx-expression-parse": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/@wordpress/stylelint-config": {
-			"version": "21.41.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"stylelint-config-recommended": "^6.0.0",
-				"stylelint-config-recommended-scss": "^5.0.2"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"stylelint": "^14.2"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/balanced-match": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/scripts/node_modules/chalk": {
-			"version": "4.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/color-convert": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/color-name": {
-			"version": "1.1.4",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/scripts/node_modules/global-modules": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"global-prefix": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/global-prefix": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ini": "^1.3.5",
-				"kind-of": "^6.0.2",
-				"which": "^1.3.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/has-flag": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/ini": {
-			"version": "1.3.8",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@wordpress/scripts/node_modules/kind-of": {
-			"version": "6.0.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/known-css-properties": {
-			"version": "0.26.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/scripts/node_modules/prettier": {
-			"name": "wp-prettier",
-			"version": "3.0.3",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"prettier": "bin/prettier.cjs"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint": {
-			"version": "14.16.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@csstools/selector-specificity": "^2.0.2",
-				"balanced-match": "^2.0.0",
-				"colord": "^2.9.3",
-				"cosmiconfig": "^7.1.0",
-				"css-functions-list": "^3.1.0",
-				"debug": "^4.3.4",
-				"fast-glob": "^3.2.12",
-				"fastest-levenshtein": "^1.0.16",
-				"file-entry-cache": "^6.0.1",
-				"global-modules": "^2.0.0",
-				"globby": "^11.1.0",
-				"globjoin": "^0.1.4",
-				"html-tags": "^3.2.0",
-				"ignore": "^5.2.1",
-				"import-lazy": "^4.0.0",
-				"imurmurhash": "^0.1.4",
-				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.26.0",
-				"mathml-tag-names": "^2.1.3",
-				"meow": "^9.0.0",
-				"micromatch": "^4.0.5",
-				"normalize-path": "^3.0.0",
-				"picocolors": "^1.0.0",
-				"postcss": "^8.4.19",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.11",
-				"postcss-value-parser": "^4.2.0",
-				"resolve-from": "^5.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"style-search": "^0.1.0",
-				"supports-hyperlinks": "^2.3.0",
-				"svg-tags": "^1.0.0",
-				"table": "^6.8.1",
-				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^4.0.2"
-			},
-			"bin": {
-				"stylelint": "bin/stylelint.js"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/stylelint"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint-config-recommended": {
-			"version": "6.0.0",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"stylelint": "^14.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint-config-recommended-scss": {
-			"version": "5.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"postcss-scss": "^4.0.2",
-				"stylelint-config-recommended": "^6.0.0",
-				"stylelint-scss": "^4.0.0"
-			},
-			"peerDependencies": {
-				"stylelint": "^14.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/stylelint-scss": {
-			"version": "4.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^6.0.11",
-				"postcss-value-parser": "^4.2.0"
-			},
-			"peerDependencies": {
-				"stylelint": "^14.5.1 || ^15.0.0"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/supports-color": {
-			"version": "7.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/supports-hyperlinks": {
-			"version": "2.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/@wordpress/shortcode": {
 			"version": "3.58.0",
 			"dev": true,
@@ -9457,7 +9162,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/10up-toolkit": {
-			"version": "6.2.0",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/10up-toolkit/-/10up-toolkit-6.4.1.tgz",
+			"integrity": "sha512-LvLs9YP5hM1HDXqfwhVtpsW0h0cjzveO/DwpjYJT1qcNm2R8WqaqlljWjZB2DmPrQh+4EWMllt6LvkS3KjDCUA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -9467,6 +9174,7 @@
 				"@svgr/webpack": "^8.1.0",
 				"@typescript-eslint/eslint-plugin": "^6.17.0",
 				"@typescript-eslint/parser": "^6.17.0",
+				"@vanilla-extract/webpack-plugin": "^2.3.13",
 				"@wordpress/dependency-extraction-webpack-plugin": "^5.4.0",
 				"@wordpress/eslint-plugin": "^17.5.0",
 				"@wordpress/jest-console": "^7.19.0",
@@ -9524,7 +9232,7 @@
 			},
 			"peerDependencies": {
 				"@10up/babel-preset-default": ">=2.1.1",
-				"@10up/eslint-config": ">=4.1.0-next.0",
+				"@10up/eslint-config": ">=4.1.1",
 				"@10up/stylelint-config": ">=3.0.0",
 				"@linaria/babel-preset": ">=4.3.3",
 				"@linaria/webpack-loader": ">=4.1.11",
@@ -9996,11 +9704,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/abab": {
-			"version": "2.0.6",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
 			"dev": true,
@@ -10014,22 +9717,15 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/acorn-globals": {
-			"version": "7.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.1.0",
-				"acorn-walk": "^8.0.2"
 			}
 		},
 		"node_modules/acorn-import-assertions": {
@@ -10043,6 +9739,7 @@
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -10053,25 +9750,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/adm-zip": {
-			"version": "0.5.14",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0"
-			}
-		},
-		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -10098,14 +9776,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ajv-errors": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"ajv": ">=5.0.0"
 			}
 		},
 		"node_modules/ajv-formats": {
@@ -10295,14 +9965,6 @@
 				"dequal": "^2.0.3"
 			}
 		},
-		"node_modules/arr-union": {
-			"version": "3.1.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/array-buffer-byte-length": {
 			"version": "1.0.1",
 			"dev": true,
@@ -10357,14 +10019,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/array-uniq": {
-			"version": "1.0.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/array.prototype.findlast": {
@@ -10490,6 +10144,7 @@
 			"version": "1.0.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -10508,17 +10163,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8"
-			}
-		},
-		"node_modules/ast-types": {
-			"version": "0.13.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/ast-types-flow": {
@@ -10628,21 +10272,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/axios": {
-			"version": "1.7.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
-			}
-		},
-		"node_modules/axios/node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/axobject-query": {
 			"version": "3.2.1",
 			"dev": true,
@@ -10740,41 +10369,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/babel-loader": {
-			"version": "8.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-cache-dir": "^3.3.1",
-				"loader-utils": "^2.0.0",
-				"make-dir": "^3.1.0",
-				"schema-utils": "^2.6.5"
-			},
-			"engines": {
-				"node": ">= 8.9"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0",
-				"webpack": ">=2"
-			}
-		},
-		"node_modules/babel-loader/node_modules/schema-utils": {
-			"version": "2.7.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/json-schema": "^7.0.5",
-				"ajv": "^6.12.4",
-				"ajv-keywords": "^3.5.2"
-			},
-			"engines": {
-				"node": ">= 8.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			}
-		},
 		"node_modules/babel-plugin-istanbul": {
 			"version": "6.1.1",
 			"dev": true,
@@ -10863,6 +10457,8 @@
 		},
 		"node_modules/babel-plugin-transform-react-remove-prop-types": {
 			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+			"integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -10903,26 +10499,6 @@
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
 			}
-		},
-		"node_modules/babel-runtime": {
-			"version": "6.25.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.10.0"
-			}
-		},
-		"node_modules/babel-runtime/node_modules/core-js": {
-			"version": "2.6.12",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT"
-		},
-		"node_modules/babel-runtime/node_modules/regenerator-runtime": {
-			"version": "0.10.5",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -10987,14 +10563,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/basic-ftp": {
-			"version": "5.0.5",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			}
 		},
 		"node_modules/batch": {
 			"version": "0.6.1",
@@ -11340,38 +10908,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/camelcase-keys": {
-			"version": "6.2.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"camelcase": "^5.3.1",
-				"map-obj": "^4.0.0",
-				"quick-lru": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/camelcase": {
-			"version": "5.3.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/quick-lru": {
-			"version": "4.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/caniuse-api": {
 			"version": "3.0.0",
 			"dev": true,
@@ -11474,94 +11010,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/check-node-version": {
-			"version": "4.2.1",
-			"dev": true,
-			"license": "Unlicense",
-			"dependencies": {
-				"chalk": "^3.0.0",
-				"map-values": "^1.0.1",
-				"minimist": "^1.2.0",
-				"object-filter": "^1.0.2",
-				"run-parallel": "^1.1.4",
-				"semver": "^6.3.0"
-			},
-			"bin": {
-				"check-node-version": "bin.js"
-			},
-			"engines": {
-				"node": ">=8.3.0"
-			}
-		},
-		"node_modules/check-node-version/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/check-node-version/node_modules/chalk": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/check-node-version/node_modules/color-convert": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/check-node-version/node_modules/color-name": {
-			"version": "1.1.4",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/check-node-version/node_modules/has-flag": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/check-node-version/node_modules/semver": {
-			"version": "6.3.1",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/check-node-version/node_modules/supports-color": {
-			"version": "7.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
 			"dev": true,
@@ -11600,23 +11048,6 @@
 			"version": "1.1.4",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/chrome-launcher": {
-			"version": "0.15.2",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@types/node": "*",
-				"escape-string-regexp": "^4.0.0",
-				"is-wsl": "^2.2.0",
-				"lighthouse-logger": "^1.0.0"
-			},
-			"bin": {
-				"print-chrome-path": "bin/print-chrome-path.js"
-			},
-			"engines": {
-				"node": ">=12.13.0"
-			}
 		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.4",
@@ -11675,21 +11106,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/clean-webpack-plugin": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/webpack": "^4.4.31",
-				"del": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.9.0"
-			},
-			"peerDependencies": {
-				"webpack": "*"
 			}
 		},
 		"node_modules/cli-cursor": {
@@ -11780,32 +11196,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8"
-			}
-		},
-		"node_modules/clone-deep": {
-			"version": "0.2.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"for-own": "^0.1.3",
-				"is-plain-object": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"lazy-cache": "^1.0.3",
-				"shallow-clone": "^0.1.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/clone-deep/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/clone-response": {
@@ -11950,11 +11340,6 @@
 				"node": ">=4.0.0"
 			}
 		},
-		"node_modules/commondir": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/compressible": {
 			"version": "2.0.18",
 			"dev": true,
@@ -12028,35 +11413,17 @@
 				"typedarray": "^0.0.6"
 			}
 		},
-		"node_modules/configstore": {
-			"version": "5.0.1",
+		"node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
 			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dot-prop": "^5.2.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^3.0.0",
-				"unique-string": "^2.0.0",
-				"write-file-atomic": "^3.0.0",
-				"xdg-basedir": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/configstore/node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
-			}
+			"license": "MIT"
 		},
 		"node_modules/confusing-browser-globals": {
 			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+			"integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -12110,14 +11477,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/cookie": {
-			"version": "0.4.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/cookie-signature": {
 			"version": "1.0.6",
 			"dev": true,
@@ -12127,70 +11486,6 @@
 			"version": "1.3.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/copy-webpack-plugin": {
-			"version": "10.2.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-glob": "^3.2.7",
-				"glob-parent": "^6.0.1",
-				"globby": "^12.0.2",
-				"normalize-path": "^3.0.0",
-				"schema-utils": "^4.0.0",
-				"serialize-javascript": "^6.0.0"
-			},
-			"engines": {
-				"node": ">= 12.20.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.1.0"
-			}
-		},
-		"node_modules/copy-webpack-plugin/node_modules/array-union": {
-			"version": "3.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/copy-webpack-plugin/node_modules/globby": {
-			"version": "12.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-union": "^3.0.1",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.7",
-				"ignore": "^5.1.9",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/copy-webpack-plugin/node_modules/slash": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/core-js": {
 			"version": "3.37.1",
@@ -12334,89 +11629,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cross-fetch": {
-			"version": "3.1.5",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"node-fetch": "2.6.7"
-			}
-		},
-		"node_modules/cross-fetch/node_modules/node-fetch": {
-			"version": "2.6.7",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/cross-fetch/node_modules/tr46": {
-			"version": "0.0.3",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cross-fetch/node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/cross-fetch/node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			}
-		},
-		"node_modules/cross-spawn": {
-			"version": "5.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
-		"node_modules/cross-spawn/node_modules/lru-cache": {
-			"version": "4.1.5",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			}
-		},
-		"node_modules/cross-spawn/node_modules/yallist": {
-			"version": "2.1.2",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/crypto-random-string": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/csp_evaluator": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/css-blank-pseudo": {
 			"version": "6.0.2",
 			"dev": true,
@@ -12456,6 +11668,7 @@
 			"version": "3.2.2",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12 || >=16"
 			}
@@ -12708,42 +11921,9 @@
 			"dev": true,
 			"license": "CC0-1.0"
 		},
-		"node_modules/cssom": {
-			"version": "0.5.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cssstyle": {
-			"version": "2.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssom": "~0.3.6"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cssstyle/node_modules/cssom": {
-			"version": "0.3.8",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
 			"license": "MIT"
-		},
-		"node_modules/cwd": {
-			"version": "0.10.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-pkg": "^0.1.2",
-				"fs-exists-sync": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
 		},
 		"node_modules/cypress": {
 			"version": "13.11.0",
@@ -12925,27 +12105,6 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "6.0.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/data-urls": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"abab": "^2.0.6",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/data-view-buffer": {
 			"version": "1.0.1",
 			"dev": true,
@@ -13046,6 +12205,7 @@
 			"version": "1.1.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -13061,14 +12221,10 @@
 			"version": "1.0.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/decimal.js": {
-			"version": "10.4.3",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
@@ -13118,6 +12274,14 @@
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/deep-object-diff": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
+			"integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/deepmerge": {
@@ -13285,81 +12449,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/degenerator": {
-			"version": "5.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ast-types": "^0.13.4",
-				"escodegen": "^2.1.0",
-				"esprima": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/del": {
-			"version": "4.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/glob": "^7.1.1",
-				"globby": "^6.1.0",
-				"is-path-cwd": "^2.0.0",
-				"is-path-in-cwd": "^2.0.0",
-				"p-map": "^2.0.0",
-				"pify": "^4.0.1",
-				"rimraf": "^2.6.3"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/del/node_modules/array-union": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-uniq": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/del/node_modules/globby": {
-			"version": "6.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-union": "^1.0.1",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/del/node_modules/globby/node_modules/pify": {
-			"version": "2.3.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/del/node_modules/rimraf": {
-			"version": "2.7.1",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"dev": true,
@@ -13424,11 +12513,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/devtools-protocol": {
-			"version": "0.0.1155343",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/diff": {
 			"version": "4.0.2",
 			"dev": true,
@@ -13480,6 +12564,7 @@
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -13532,17 +12617,6 @@
 			],
 			"license": "BSD-2-Clause"
 		},
-		"node_modules/domexception": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"webidl-conversions": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/domhandler": {
 			"version": "4.3.1",
 			"dev": true,
@@ -13576,17 +12650,6 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/dot-prop": {
-			"version": "5.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-obj": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/downshift": {
@@ -13714,17 +12777,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/envinfo": {
-			"version": "7.13.0",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"envinfo": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/equivalent-key-map": {
@@ -13907,6 +12959,47 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/esbuild": {
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
+			"integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.25.4",
+				"@esbuild/android-arm": "0.25.4",
+				"@esbuild/android-arm64": "0.25.4",
+				"@esbuild/android-x64": "0.25.4",
+				"@esbuild/darwin-arm64": "0.25.4",
+				"@esbuild/darwin-x64": "0.25.4",
+				"@esbuild/freebsd-arm64": "0.25.4",
+				"@esbuild/freebsd-x64": "0.25.4",
+				"@esbuild/linux-arm": "0.25.4",
+				"@esbuild/linux-arm64": "0.25.4",
+				"@esbuild/linux-ia32": "0.25.4",
+				"@esbuild/linux-loong64": "0.25.4",
+				"@esbuild/linux-mips64el": "0.25.4",
+				"@esbuild/linux-ppc64": "0.25.4",
+				"@esbuild/linux-riscv64": "0.25.4",
+				"@esbuild/linux-s390x": "0.25.4",
+				"@esbuild/linux-x64": "0.25.4",
+				"@esbuild/netbsd-arm64": "0.25.4",
+				"@esbuild/netbsd-x64": "0.25.4",
+				"@esbuild/openbsd-arm64": "0.25.4",
+				"@esbuild/openbsd-x64": "0.25.4",
+				"@esbuild/sunos-x64": "0.25.4",
+				"@esbuild/win32-arm64": "0.25.4",
+				"@esbuild/win32-ia32": "0.25.4",
+				"@esbuild/win32-x64": "0.25.4"
+			}
+		},
 		"node_modules/escalade": {
 			"version": "3.1.2",
 			"dev": true,
@@ -13930,38 +13023,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/escodegen": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"esprima": "^4.0.1",
-				"estraverse": "^5.2.0",
-				"esutils": "^2.0.2"
-			},
-			"bin": {
-				"escodegen": "bin/escodegen.js",
-				"esgenerate": "bin/esgenerate.js"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"optionalDependencies": {
-				"source-map": "~0.6.1"
-			}
-		},
-		"node_modules/escodegen/node_modules/source-map": {
-			"version": "0.6.1",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/eslint": {
 			"version": "8.57.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -14014,6 +13079,8 @@
 		},
 		"node_modules/eslint-config-airbnb": {
 			"version": "19.0.4",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+			"integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -14035,6 +13102,8 @@
 		},
 		"node_modules/eslint-config-airbnb-base": {
 			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+			"integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -14054,6 +13123,8 @@
 		},
 		"node_modules/eslint-config-airbnb-base/node_modules/semver": {
 			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -14323,19 +13394,24 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "48.2.9",
+			"version": "48.11.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.11.0.tgz",
+			"integrity": "sha512-d12JHJDPNo7IFwTOAItCeJY1hcqoIxE0lHA8infQByLilQ9xkqrRa6laWCnsuCrf+8rUnvxXY1XuTbibRBNylA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"peer": true,
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.43.1",
+				"@es-joy/jsdoccomment": "~0.46.0",
 				"are-docs-informative": "^0.0.2",
 				"comment-parser": "1.4.1",
-				"debug": "^4.3.4",
+				"debug": "^4.3.5",
 				"escape-string-regexp": "^4.0.0",
-				"esquery": "^1.5.0",
-				"semver": "^7.6.2",
-				"spdx-expression-parse": "^4.0.0"
+				"espree": "^10.1.0",
+				"esquery": "^1.6.0",
+				"parse-imports": "^2.1.1",
+				"semver": "^7.6.3",
+				"spdx-expression-parse": "^4.0.0",
+				"synckit": "^0.9.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -14345,33 +13421,70 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/@es-joy/jsdoccomment": {
-			"version": "0.43.1",
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.46.0.tgz",
+			"integrity": "sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@types/eslint": "^8.56.5",
-				"@types/estree": "^1.0.5",
-				"@typescript-eslint/types": "^7.2.0",
 				"comment-parser": "1.4.1",
-				"esquery": "^1.5.0",
+				"esquery": "^1.6.0",
 				"jsdoc-type-pratt-parser": "~4.0.0"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/@typescript-eslint/types": {
-			"version": "7.13.0",
+		"node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.14.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/synckit": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+			"integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
+			"dependencies": {
+				"@pkgr/core": "^0.1.0",
+				"tslib": "^2.6.2"
+			},
 			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
+				"url": "https://opencollective.com/unts"
 			}
 		},
 		"node_modules/eslint-plugin-jsx-a11y": {
@@ -14617,6 +13730,7 @@
 		"node_modules/eslint/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -14629,11 +13743,13 @@
 		},
 		"node_modules/eslint/node_modules/argparse": {
 			"version": "2.0.1",
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -14642,6 +13758,7 @@
 		"node_modules/eslint/node_modules/chalk": {
 			"version": "4.1.2",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -14656,6 +13773,7 @@
 		"node_modules/eslint/node_modules/color-convert": {
 			"version": "2.0.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -14665,11 +13783,13 @@
 		},
 		"node_modules/eslint/node_modules/color-name": {
 			"version": "1.1.4",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/eslint/node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -14682,6 +13802,7 @@
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "7.2.2",
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -14696,6 +13817,7 @@
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -14706,6 +13828,7 @@
 		"node_modules/eslint/node_modules/find-up": {
 			"version": "5.0.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -14720,6 +13843,7 @@
 		"node_modules/eslint/node_modules/has-flag": {
 			"version": "4.0.0",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -14727,6 +13851,7 @@
 		"node_modules/eslint/node_modules/js-yaml": {
 			"version": "4.1.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -14737,6 +13862,7 @@
 		"node_modules/eslint/node_modules/locate-path": {
 			"version": "6.0.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -14750,6 +13876,7 @@
 		"node_modules/eslint/node_modules/minimatch": {
 			"version": "3.1.2",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -14760,6 +13887,7 @@
 		"node_modules/eslint/node_modules/p-locate": {
 			"version": "5.0.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -14773,6 +13901,7 @@
 		"node_modules/eslint/node_modules/shebang-command": {
 			"version": "2.0.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -14783,6 +13912,7 @@
 		"node_modules/eslint/node_modules/shebang-regex": {
 			"version": "3.0.0",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -14790,6 +13920,7 @@
 		"node_modules/eslint/node_modules/supports-color": {
 			"version": "7.2.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -14800,6 +13931,7 @@
 		"node_modules/eslint/node_modules/which": {
 			"version": "2.0.2",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -14813,6 +13945,7 @@
 		"node_modules/espree": {
 			"version": "9.6.1",
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -14828,6 +13961,7 @@
 		"node_modules/espree/node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
@@ -14848,7 +13982,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.5.0",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -14887,6 +14023,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eval": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/eval/-/eval-0.1.8.tgz",
+			"integrity": "sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"require-like": ">= 0.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/eventemitter2": {
@@ -15013,17 +14162,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/expand-tilde": {
-			"version": "1.2.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"os-homedir": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/expect": {
 			"version": "29.7.0",
 			"dev": true,
@@ -15038,11 +14176,6 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
-		},
-		"node_modules/expect-puppeteer": {
-			"version": "4.4.0",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/express": {
 			"version": "4.19.2",
@@ -15244,12 +14377,14 @@
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4.9.1"
 			}
@@ -15313,35 +14448,12 @@
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
 			"engines": {
 				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/filename-reserved-regex": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/filenamify": {
-			"version": "4.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.1",
-				"trim-repeated": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/fill-range": {
@@ -15384,134 +14496,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/find-cache-dir": {
-			"version": "3.3.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"commondir": "^1.0.1",
-				"make-dir": "^3.0.2",
-				"pkg-dir": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-			}
-		},
-		"node_modules/find-file-up": {
-			"version": "0.1.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fs-exists-sync": "^0.1.0",
-				"resolve-dir": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/find-parent-dir": {
 			"version": "0.3.1",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/find-pkg": {
-			"version": "0.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-file-up": "^0.1.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/find-process": {
-			"version": "1.4.7",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.0.0",
-				"commander": "^5.1.0",
-				"debug": "^4.1.1"
-			},
-			"bin": {
-				"find-process": "bin/find-process.js"
-			}
-		},
-		"node_modules/find-process/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/find-process/node_modules/chalk": {
-			"version": "4.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/find-process/node_modules/color-convert": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/find-process/node_modules/color-name": {
-			"version": "1.1.4",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/find-process/node_modules/commander": {
-			"version": "5.1.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/find-process/node_modules/has-flag": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/find-process/node_modules/supports-color": {
-			"version": "7.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/find-root": {
 			"version": "1.1.0",
@@ -15529,17 +14517,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/flat": {
-			"version": "5.0.2",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"bin": {
-				"flat": "cli.js"
-			}
-		},
 		"node_modules/flat-cache": {
 			"version": "3.2.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.3",
@@ -15551,7 +14532,8 @@
 		},
 		"node_modules/flatted": {
 			"version": "3.3.1",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.6",
@@ -15580,44 +14562,12 @@
 				"is-callable": "^1.1.3"
 			}
 		},
-		"node_modules/for-in": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/for-own": {
-			"version": "0.1.5",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"for-in": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/forever-agent": {
 			"version": "0.6.1",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/forwarded": {
@@ -15690,14 +14640,6 @@
 			"version": "1.0.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/fs-exists-sync": {
-			"version": "0.1.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/fs-extra": {
 			"version": "9.1.0",
@@ -15821,28 +14763,6 @@
 				"node": ">=8.0.0"
 			}
 		},
-		"node_modules/get-port": {
-			"version": "5.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/get-stdin": {
-			"version": "9.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
 			"dev": true,
@@ -15871,33 +14791,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-uri": {
-			"version": "6.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"basic-ftp": "^5.0.2",
-				"data-uri-to-buffer": "^6.0.2",
-				"debug": "^4.3.4",
-				"fs-extra": "^11.2.0"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/get-uri/node_modules/fs-extra": {
-			"version": "11.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
 			}
 		},
 		"node_modules/getos": {
@@ -15995,37 +14888,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/global-modules": {
-			"version": "0.2.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"global-prefix": "^0.1.4",
-				"is-windows": "^0.2.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/global-prefix": {
-			"version": "0.1.5",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"homedir-polyfill": "^1.0.0",
-				"ini": "^1.3.4",
-				"is-windows": "^0.2.0",
-				"which": "^1.2.12"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/global-prefix/node_modules/ini": {
-			"version": "1.3.8",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/globals": {
 			"version": "13.24.0",
 			"license": "MIT",
@@ -16075,7 +14937,8 @@
 		"node_modules/globjoin": {
 			"version": "0.1.4",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/good-listener": {
 			"version": "1.2.2",
@@ -16159,6 +15022,7 @@
 			"version": "2.1.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -16267,21 +15131,11 @@
 			"version": "16.13.1",
 			"license": "MIT"
 		},
-		"node_modules/homedir-polyfill": {
-			"version": "1.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"parse-passwd": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/hosted-git-info": {
 			"version": "4.1.0",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -16293,6 +15147,7 @@
 			"version": "6.0.0",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -16303,7 +15158,8 @@
 		"node_modules/hosted-git-info/node_modules/yallist": {
 			"version": "4.0.0",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/hpack.js": {
 			"version": "2.1.6",
@@ -16320,17 +15176,6 @@
 			"version": "1.4.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/html-encoding-sniffer": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-encoding": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/html-entities": {
 			"version": "2.5.2",
@@ -16384,6 +15229,7 @@
 			"version": "3.3.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -16473,14 +15319,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/http-link-header": {
-			"version": "1.1.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/http-parser-js": {
 			"version": "0.5.8",
 			"dev": true,
@@ -16497,19 +15335,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/http-proxy-agent": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tootallnate/once": "2",
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/http-proxy-middleware": {
@@ -16558,18 +15383,6 @@
 			},
 			"engines": {
 				"node": ">=10.19.0"
-			}
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/human-signals": {
@@ -16633,37 +15446,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/ignore-walk": {
-			"version": "4.0.1",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minimatch": "^3.0.4"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/ignore-walk/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/ignore-walk/node_modules/minimatch": {
-			"version": "3.1.2",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/image-minimizer-webpack-plugin": {
 			"version": "3.8.3",
 			"dev": true,
@@ -16697,11 +15479,6 @@
 				}
 			}
 		},
-		"node_modules/image-ssim": {
-			"version": "0.2.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/immutable": {
 			"version": "4.3.6",
 			"dev": true,
@@ -16732,6 +15509,7 @@
 			"version": "4.0.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -16894,27 +15672,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/interpret": {
-			"version": "3.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/intl-messageformat": {
-			"version": "4.4.0",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"intl-messageformat-parser": "^1.8.1"
-			}
-		},
-		"node_modules/intl-messageformat-parser": {
-			"version": "1.8.1",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/invariant": {
 			"version": "2.2.4",
 			"dev": true,
@@ -16923,37 +15680,12 @@
 				"loose-envify": "^1.0.0"
 			}
 		},
-		"node_modules/ip-address": {
-			"version": "9.0.5",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/ip-address/node_modules/jsbn": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/ipaddr.js": {
 			"version": "2.2.0",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/irregular-plurals": {
-			"version": "3.5.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -17025,11 +15757,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/is-buffer": {
-			"version": "1.1.6",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/is-builtin-module": {
 			"version": "3.2.1",
@@ -17117,14 +15844,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-extendable": {
-			"version": "0.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -17251,44 +15970,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-obj": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/is-path-cwd": {
-			"version": "2.2.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/is-path-in-cwd": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-path-inside": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/is-path-in-cwd/node_modules/is-path-inside": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-is-inside": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/is-path-inside": {
 			"version": "3.0.3",
 			"license": "MIT",
@@ -17313,11 +15994,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/is-potential-custom-element-name": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/is-promise": {
 			"version": "4.0.0",
@@ -17470,14 +16146,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-windows": {
-			"version": "0.2.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-wsl": {
 			"version": "2.2.0",
 			"dev": true,
@@ -17497,14 +16165,6 @@
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"license": "ISC"
-		},
-		"node_modules/isobject": {
-			"version": "3.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/isomorphic.js": {
 			"version": "0.2.5",
@@ -17641,6 +16301,13 @@
 				"reflect.getprototypeof": "^1.0.4",
 				"set-function-name": "^2.0.1"
 			}
+		},
+		"node_modules/javascript-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.1.0.tgz",
+			"integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/jest": {
 			"version": "29.7.0",
@@ -18065,86 +16732,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/jest-dev-server": {
-			"version": "9.0.2",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.1.2",
-				"cwd": "^0.10.0",
-				"find-process": "^1.4.7",
-				"prompts": "^2.4.2",
-				"spawnd": "^9.0.2",
-				"tree-kill": "^1.2.2",
-				"wait-on": "^7.2.0"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/jest-dev-server/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-dev-server/node_modules/chalk": {
-			"version": "4.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest-dev-server/node_modules/color-convert": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/jest-dev-server/node_modules/color-name": {
-			"version": "1.1.4",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jest-dev-server/node_modules/has-flag": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-dev-server/node_modules/supports-color": {
-			"version": "7.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/jest-diff": {
 			"version": "29.7.0",
 			"dev": true,
@@ -18311,32 +16898,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/jest-environment-jsdom": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/jsdom": "^20.0.0",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jsdom": "^20.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"canvas": "^2.5.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/jest-environment-node": {
@@ -19263,31 +17824,6 @@
 				"jiti": "bin/jiti.js"
 			}
 		},
-		"node_modules/joi": {
-			"version": "17.13.1",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^9.3.0",
-				"@hapi/topo": "^5.1.0",
-				"@sideway/address": "^4.1.5",
-				"@sideway/formula": "^3.0.1",
-				"@sideway/pinpoint": "^2.0.0"
-			}
-		},
-		"node_modules/jpeg-js": {
-			"version": "0.4.4",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/js-library-detector": {
-			"version": "6.7.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"license": "MIT"
@@ -19315,50 +17851,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/jsdom": {
-			"version": "20.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"abab": "^2.0.6",
-				"acorn": "^8.8.1",
-				"acorn-globals": "^7.0.0",
-				"cssom": "^0.5.0",
-				"cssstyle": "^2.3.0",
-				"data-urls": "^3.0.2",
-				"decimal.js": "^10.4.2",
-				"domexception": "^4.0.0",
-				"escodegen": "^2.0.0",
-				"form-data": "^4.0.0",
-				"html-encoding-sniffer": "^3.0.0",
-				"http-proxy-agent": "^5.0.0",
-				"https-proxy-agent": "^5.0.1",
-				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.2",
-				"parse5": "^7.1.1",
-				"saxes": "^6.0.0",
-				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^4.1.2",
-				"w3c-xmlserializer": "^4.0.0",
-				"webidl-conversions": "^7.0.0",
-				"whatwg-encoding": "^2.0.0",
-				"whatwg-mimetype": "^3.0.0",
-				"whatwg-url": "^11.0.0",
-				"ws": "^8.11.0",
-				"xml-name-validator": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"canvas": "^2.5.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/jsesc": {
@@ -19390,7 +17882,8 @@
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
@@ -19412,11 +17905,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/jsonc-parser": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
@@ -19464,31 +17952,12 @@
 				"json-buffer": "3.0.1"
 			}
 		},
-		"node_modules/kind-of": {
-			"version": "3.2.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-buffer": "^1.1.5"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/kleur": {
 			"version": "3.0.3",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/klona": {
-			"version": "2.0.6",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/known-css-properties": {
@@ -19529,14 +17998,6 @@
 				"node": "> 0.8"
 			}
 		},
-		"node_modules/lazy-cache": {
-			"version": "1.0.4",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"dev": true,
@@ -19548,6 +18009,7 @@
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -19576,195 +18038,6 @@
 				"url": "https://github.com/sponsors/dmonad"
 			}
 		},
-		"node_modules/lighthouse": {
-			"version": "10.4.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sentry/node": "^6.17.4",
-				"axe-core": "4.7.2",
-				"chrome-launcher": "^0.15.2",
-				"configstore": "^5.0.1",
-				"csp_evaluator": "1.1.1",
-				"devtools-protocol": "0.0.1155343",
-				"enquirer": "^2.3.6",
-				"http-link-header": "^1.1.1",
-				"intl-messageformat": "^4.4.0",
-				"jpeg-js": "^0.4.4",
-				"js-library-detector": "^6.6.0",
-				"lighthouse-logger": "^1.4.1",
-				"lighthouse-stack-packs": "1.11.0",
-				"lodash": "^4.17.21",
-				"lookup-closest-locale": "6.2.0",
-				"metaviewport-parser": "0.3.0",
-				"open": "^8.4.0",
-				"parse-cache-control": "1.0.1",
-				"ps-list": "^8.0.0",
-				"puppeteer-core": "^20.8.0",
-				"robots-parser": "^3.0.0",
-				"semver": "^5.3.0",
-				"speedline-core": "^1.4.3",
-				"third-party-web": "^0.23.3",
-				"ws": "^7.0.0",
-				"yargs": "^17.3.1",
-				"yargs-parser": "^21.0.0"
-			},
-			"bin": {
-				"chrome-debug": "core/scripts/manual-chrome-launcher.js",
-				"lighthouse": "cli/index.js",
-				"smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
-			},
-			"engines": {
-				"node": ">=16.16"
-			}
-		},
-		"node_modules/lighthouse-logger": {
-			"version": "1.4.2",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"debug": "^2.6.9",
-				"marky": "^1.2.2"
-			}
-		},
-		"node_modules/lighthouse-logger/node_modules/debug": {
-			"version": "2.6.9",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/lighthouse-logger/node_modules/ms": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lighthouse-stack-packs": {
-			"version": "1.11.0",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/lighthouse/node_modules/axe-core": {
-			"version": "4.7.2",
-			"dev": true,
-			"license": "MPL-2.0",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/lighthouse/node_modules/cross-fetch": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"node-fetch": "^2.6.12"
-			}
-		},
-		"node_modules/lighthouse/node_modules/debug": {
-			"version": "4.3.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "20.9.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@puppeteer/browsers": "1.4.6",
-				"chromium-bidi": "0.4.16",
-				"cross-fetch": "4.0.0",
-				"debug": "4.3.4",
-				"devtools-protocol": "0.0.1147663",
-				"ws": "8.13.0"
-			},
-			"engines": {
-				"node": ">=16.3.0"
-			},
-			"peerDependencies": {
-				"typescript": ">= 4.7.4"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "0.4.16",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"mitt": "3.0.0"
-			},
-			"peerDependencies": {
-				"devtools-protocol": "*"
-			}
-		},
-		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1147663",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.13.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/lighthouse/node_modules/semver": {
-			"version": "5.7.2",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/lighthouse/node_modules/ws": {
-			"version": "7.5.9",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/lilconfig": {
 			"version": "3.1.2",
 			"dev": true,
@@ -19790,14 +18063,6 @@
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"license": "MIT"
-		},
-		"node_modules/linkify-it": {
-			"version": "3.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"uc.micro": "^1.0.1"
-			}
 		},
 		"node_modules/listr2": {
 			"version": "3.14.0",
@@ -19896,7 +18161,8 @@
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
@@ -19906,7 +18172,8 @@
 		"node_modules/lodash.truncate": {
 			"version": "4.4.2",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lodash.uniq": {
 			"version": "4.5.0",
@@ -20068,11 +18335,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/lookup-closest-locale": {
-			"version": "6.2.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"license": "MIT",
@@ -20098,39 +18360,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/lru_map": {
-			"version": "0.3.3",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"node_modules/make-dir": {
-			"version": "3.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/make-dir/node_modules/semver": {
-			"version": "6.3.1",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/makeerror": {
@@ -20145,44 +18380,12 @@
 			"version": "4.3.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/map-values": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "Public Domain"
-		},
-		"node_modules/markdown-it": {
-			"version": "12.3.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1",
-				"entities": "~2.1.0",
-				"linkify-it": "^3.0.1",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
-			},
-			"bin": {
-				"markdown-it": "bin/markdown-it.js"
-			}
-		},
-		"node_modules/markdown-it/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
-		"node_modules/markdown-it/node_modules/entities": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/markdown-table": {
@@ -20197,106 +18400,11 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/markdownlint": {
-			"version": "0.25.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"markdown-it": "12.3.2"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/markdownlint-cli": {
-			"version": "0.31.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"commander": "~9.0.0",
-				"get-stdin": "~9.0.0",
-				"glob": "~7.2.0",
-				"ignore": "~5.2.0",
-				"js-yaml": "^4.1.0",
-				"jsonc-parser": "~3.0.0",
-				"markdownlint": "~0.25.1",
-				"markdownlint-rule-helpers": "~0.16.0",
-				"minimatch": "~3.0.5",
-				"run-con": "~1.2.10"
-			},
-			"bin": {
-				"markdownlint": "markdownlint.js"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
-		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/commander": {
-			"version": "9.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || >=14"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/ignore": {
-			"version": "5.2.4",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/minimatch": {
-			"version": "3.0.8",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/markdownlint-rule-helpers": {
-			"version": "0.16.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/marky": {
-			"version": "1.2.5",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/mathml-tag-names": {
 			"version": "2.1.3",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
@@ -20307,10 +18415,15 @@
 			"dev": true,
 			"license": "CC0-1.0"
 		},
-		"node_modules/mdurl": {
-			"version": "1.0.1",
+		"node_modules/media-query-parser": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/media-query-parser/-/media-query-parser-2.0.2.tgz",
+			"integrity": "sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			}
 		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
@@ -20340,63 +18453,6 @@
 			"version": "5.2.1",
 			"license": "MIT"
 		},
-		"node_modules/meow": {
-			"version": "9.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/minimist": "^1.2.0",
-				"camelcase-keys": "^6.2.2",
-				"decamelize": "^1.2.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.0",
-				"read-pkg-up": "^7.0.1",
-				"redent": "^3.0.0",
-				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.18.0",
-				"yargs-parser": "^20.2.3"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/type-fest": {
-			"version": "0.18.1",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/merge-deep": {
-			"version": "3.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"arr-union": "^3.1.0",
-				"clone-deep": "^0.2.4",
-				"kind-of": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/merge-descriptors": {
 			"version": "1.0.1",
 			"dev": true,
@@ -20413,11 +18469,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/metaviewport-parser": {
-			"version": "0.3.0",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/methods": {
 			"version": "1.1.2",
@@ -20436,17 +18487,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/mime-db": {
@@ -20488,6 +18528,7 @@
 			"version": "1.0.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -20541,6 +18582,7 @@
 			"version": "4.1.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0",
@@ -20554,6 +18596,7 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -20562,31 +18605,7 @@
 			"version": "6.0.3",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mitt": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/mixin-object": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mixin-object/node_modules/for-in": {
-			"version": "0.1.8",
-			"dev": true,
-			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -20604,6 +18623,26 @@
 		},
 		"node_modules/mkdirp-classic": {
 			"version": "0.5.3",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mlly": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+			"integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.14.0",
+				"pathe": "^2.0.1",
+				"pkg-types": "^1.3.0",
+				"ufo": "^1.5.4"
+			}
+		},
+		"node_modules/modern-ahocorasick": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/modern-ahocorasick/-/modern-ahocorasick-1.1.0.tgz",
+			"integrity": "sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -20699,14 +18738,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/netmask": {
-			"version": "2.0.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
 			"license": "MIT",
@@ -20791,6 +18822,7 @@
 			"version": "3.0.3",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
 				"is-core-module": "^2.5.0",
@@ -20833,188 +18865,6 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/npm-bundled": {
-			"version": "1.1.2",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-normalize-package-bin": "^1.0.1"
-			}
-		},
-		"node_modules/npm-normalize-package-bin": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/npm-package-json-lint": {
-			"version": "6.4.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ajv": "^6.12.6",
-				"ajv-errors": "^1.0.1",
-				"chalk": "^4.1.2",
-				"cosmiconfig": "^8.0.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"ignore": "^5.2.0",
-				"is-plain-obj": "^3.0.0",
-				"jsonc-parser": "^3.2.0",
-				"log-symbols": "^4.1.0",
-				"meow": "^9.0.0",
-				"plur": "^4.0.0",
-				"semver": "^7.3.8",
-				"slash": "^3.0.0",
-				"strip-json-comments": "^3.1.1",
-				"type-fest": "^3.2.0",
-				"validate-npm-package-name": "^5.0.0"
-			},
-			"bin": {
-				"npmPkgJsonLint": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=14.0.0",
-				"npm": ">=6.0.0"
-			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
-		"node_modules/npm-package-json-lint/node_modules/chalk": {
-			"version": "4.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/color-convert": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/color-name": {
-			"version": "1.1.4",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/npm-package-json-lint/node_modules/cosmiconfig": {
-			"version": "8.3.6",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0",
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/has-flag": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/jsonc-parser": {
-			"version": "3.2.1",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/npm-package-json-lint/node_modules/supports-color": {
-			"version": "7.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm-package-json-lint/node_modules/type-fest": {
-			"version": "3.13.1",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm-packlist": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.6",
-				"ignore-walk": "^4.0.1",
-				"npm-bundled": "^1.1.1",
-				"npm-normalize-package-bin": "^1.0.1"
-			},
-			"bin": {
-				"npm-packlist": "bin/index.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"dev": true,
@@ -21037,11 +18887,6 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
-		"node_modules/nwsapi": {
-			"version": "2.2.10",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"dev": true,
@@ -21049,11 +18894,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/object-filter": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/object-inspect": {
 			"version": "1.13.1",
@@ -21235,6 +19075,7 @@
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -21404,14 +19245,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/os-homedir": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/os-tmpdir": {
 			"version": "1.0.2",
 			"dev": true,
@@ -21471,14 +19304,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-map": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/p-retry": {
 			"version": "4.6.2",
 			"dev": true,
@@ -21499,71 +19324,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/pac-proxy-agent": {
-			"version": "7.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tootallnate/quickjs-emscripten": "^0.23.0",
-				"agent-base": "^7.0.2",
-				"debug": "^4.3.4",
-				"get-uri": "^6.0.1",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.2",
-				"pac-resolver": "^7.0.0",
-				"socks-proxy-agent": "^8.0.2"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/pac-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-			"version": "7.0.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.0.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/pac-resolver": {
-			"version": "7.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"degenerator": "^5.0.0",
-				"netmask": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
 			"license": "MIT",
@@ -21582,9 +19342,20 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/parse-cache-control": {
-			"version": "1.0.1",
-			"dev": true
+		"node_modules/parse-imports": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
+			"integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
+			"dev": true,
+			"license": "Apache-2.0 AND MIT",
+			"peer": true,
+			"dependencies": {
+				"es-module-lexer": "^1.5.3",
+				"slashes": "^3.0.12"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
 		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
@@ -21600,25 +19371,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/parse-passwd": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/parse5": {
-			"version": "7.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/parseurl": {
@@ -21659,11 +19411,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/path-is-inside": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "(WTFPL OR MIT)"
-		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"license": "MIT",
@@ -21686,6 +19433,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pend": {
 			"version": "1.2.0",
@@ -21711,33 +19465,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pify": {
-			"version": "4.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/pinkie": {
-			"version": "2.0.4",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pinkie-promise": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pinkie": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/pirates": {
 			"version": "4.0.6",
 			"dev": true,
@@ -21757,61 +19484,16 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/playwright": {
-			"version": "1.44.1",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"playwright-core": "1.44.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/playwright-core": {
-			"version": "1.44.1",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/playwright/node_modules/fsevents": {
-			"version": "2.3.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/plur": {
-			"version": "4.0.0",
+		"node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"irregular-plurals": "^3.2.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
 			}
 		},
 		"node_modules/possible-typed-array-names": {
@@ -22361,27 +20043,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
-			}
-		},
-		"node_modules/postcss-loader": {
-			"version": "6.2.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cosmiconfig": "^7.0.0",
-				"klona": "^2.0.5",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"postcss": "^7.0.0 || ^8.0.1",
-				"webpack": "^5.0.0"
 			}
 		},
 		"node_modules/postcss-logical": {
@@ -22984,6 +20645,7 @@
 			"version": "6.0.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12.0"
 			},
@@ -23153,6 +20815,7 @@
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -23248,14 +20911,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/progress": {
-			"version": "2.0.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
 			"dev": true,
@@ -23303,72 +20958,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/proxy-agent": {
-			"version": "6.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.0.2",
-				"debug": "^4.3.4",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.0",
-				"lru-cache": "^7.14.1",
-				"pac-proxy-agent": "^7.0.0",
-				"proxy-from-env": "^1.1.0",
-				"socks-proxy-agent": "^8.0.1"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/proxy-agent/node_modules/agent-base": {
-			"version": "7.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/proxy-agent/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/proxy-agent/node_modules/https-proxy-agent": {
-			"version": "7.0.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.0.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/proxy-agent/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/proxy-agent/node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/proxy-compare": {
 			"version": "2.3.0",
 			"dev": true,
@@ -23378,22 +20967,6 @@
 			"version": "1.0.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/ps-list": {
-			"version": "8.1.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/pseudomap": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/psl": {
 			"version": "1.9.0",
@@ -23414,93 +20987,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/puppeteer-core": {
-			"version": "13.7.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"cross-fetch": "3.1.5",
-				"debug": "4.3.4",
-				"devtools-protocol": "0.0.981744",
-				"extract-zip": "2.0.1",
-				"https-proxy-agent": "5.0.1",
-				"pkg-dir": "4.2.0",
-				"progress": "2.0.3",
-				"proxy-from-env": "1.1.0",
-				"rimraf": "3.0.2",
-				"tar-fs": "2.1.1",
-				"unbzip2-stream": "1.4.3",
-				"ws": "8.5.0"
-			},
-			"engines": {
-				"node": ">=10.18.1"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/debug": {
-			"version": "4.3.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.981744",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/puppeteer-core/node_modules/extract-zip": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
-			}
-		},
-		"node_modules/puppeteer-core/node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.5.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/pure-rand": {
@@ -23924,29 +21410,6 @@
 				"node": ">=8.10.0"
 			}
 		},
-		"node_modules/rechoir": {
-			"version": "0.8.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"resolve": "^1.20.0"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/redent": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"indent-string": "^4.0.0",
-				"strip-indent": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/redux": {
 			"version": "4.2.1",
 			"dev": true,
@@ -24121,6 +21584,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/require-like": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
+			"integrity": "sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/require-main-filename": {
 			"version": "2.0.0",
 			"dev": true,
@@ -24159,14 +21631,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/resolve-bin": {
-			"version": "0.4.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-parent-dir": "~0.3.0"
-			}
-		},
 		"node_modules/resolve-cwd": {
 			"version": "3.0.0",
 			"dev": true,
@@ -24176,18 +21640,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/resolve-dir": {
-			"version": "0.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expand-tilde": "^1.2.2",
-				"global-modules": "^0.2.3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/resolve-from": {
@@ -24263,108 +21715,12 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/robots-parser": {
-			"version": "3.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/rtlcss": {
-			"version": "3.5.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^5.0.0",
-				"picocolors": "^1.0.0",
-				"postcss": "^8.3.11",
-				"strip-json-comments": "^3.1.1"
-			},
-			"bin": {
-				"rtlcss": "bin/rtlcss.js"
-			}
-		},
-		"node_modules/rtlcss-webpack-plugin": {
-			"version": "4.0.7",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"babel-runtime": "~6.25.0",
-				"rtlcss": "^3.5.0"
-			}
-		},
-		"node_modules/rtlcss/node_modules/find-up": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"locate-path": "^6.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/rtlcss/node_modules/locate-path": {
-			"version": "6.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-locate": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/rtlcss/node_modules/p-locate": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"p-limit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/run-async": {
 			"version": "2.4.1",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/run-con": {
-			"version": "1.2.12",
-			"dev": true,
-			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-			"dependencies": {
-				"deep-extend": "^0.6.0",
-				"ini": "~3.0.0",
-				"minimist": "^1.2.8",
-				"strip-json-comments": "~3.1.1"
-			},
-			"bin": {
-				"run-con": "cli.js"
-			}
-		},
-		"node_modules/run-con/node_modules/ini": {
-			"version": "3.0.1",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -24487,54 +21843,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/sass-loader": {
-			"version": "12.6.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"klona": "^2.0.4",
-				"neo-async": "^2.6.2"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"fibers": ">= 3.1.0",
-				"node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-				"sass": "^1.3.0",
-				"sass-embedded": "*",
-				"webpack": "^5.0.0"
-			},
-			"peerDependenciesMeta": {
-				"fibers": {
-					"optional": true
-				},
-				"node-sass": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/saxes": {
-			"version": "6.0.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"xmlchars": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=v12.22.7"
-			}
-		},
 		"node_modules/scheduler": {
 			"version": "0.23.2",
 			"license": "MIT",
@@ -24614,7 +21922,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.2",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -24816,39 +22126,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/shallow-clone": {
-			"version": "0.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^2.0.1",
-				"lazy-cache": "^0.2.3",
-				"mixin-object": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/shallow-clone/node_modules/kind-of": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-buffer": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/shallow-clone/node_modules/lazy-cache": {
-			"version": "0.2.7",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/sharp": {
 			"version": "0.32.6",
 			"dev": true,
@@ -24892,25 +22169,6 @@
 				"b4a": "^1.6.4",
 				"fast-fifo": "^1.2.0",
 				"streamx": "^2.15.0"
-			}
-		},
-		"node_modules/shebang-command": {
-			"version": "1.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/shell-quote": {
@@ -25282,6 +22540,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/slashes": {
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
+			"integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true
+		},
 		"node_modules/slice-ansi": {
 			"version": "3.0.0",
 			"dev": true,
@@ -25325,15 +22591,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
 		"node_modules/snake-case": {
 			"version": "3.0.4",
 			"license": "MIT",
@@ -25360,43 +22617,6 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
-		"node_modules/socks": {
-			"version": "2.8.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ip-address": "^9.0.5",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks-proxy-agent": {
-			"version": "8.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.1",
-				"debug": "^4.3.4",
-				"socks": "^2.7.1"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/socks-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/source-map": {
 			"version": "0.5.7",
 			"license": "BSD-3-Clause",
@@ -25410,26 +22630,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/source-map-loader": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"abab": "^2.0.5",
-				"iconv-lite": "^0.6.3",
-				"source-map-js": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 12.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.0.0"
 			}
 		},
 		"node_modules/source-map-support": {
@@ -25447,28 +22647,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/spawnd": {
-			"version": "9.0.2",
-			"dev": true,
-			"dependencies": {
-				"signal-exit": "^4.1.0",
-				"tree-kill": "^1.2.2"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/spawnd/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/spdx-correct": {
@@ -25547,19 +22725,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/speedline-core": {
-			"version": "1.4.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"image-ssim": "^0.2.0",
-				"jpeg-js": "^0.4.1"
-			},
-			"engines": {
-				"node": ">=8.0"
 			}
 		},
 		"node_modules/sprintf-js": {
@@ -25781,17 +22946,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/strip-indent": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"min-indent": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"license": "MIT",
@@ -25802,29 +22956,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/strip-outer": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/strip-outer/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/style-search": {
 			"version": "0.1.0",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/stylehacks": {
 			"version": "6.1.1",
@@ -26461,7 +23597,8 @@
 		},
 		"node_modules/svg-tags": {
 			"version": "1.0.0",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/svgo": {
 			"version": "3.3.2",
@@ -26550,11 +23687,6 @@
 				"url": "https://github.com/fb55/domutils?sponsor=1"
 			}
 		},
-		"node_modules/symbol-tree": {
-			"version": "3.2.4",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/synckit": {
 			"version": "0.8.8",
 			"dev": true,
@@ -26574,6 +23706,7 @@
 			"version": "6.8.2",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.1",
 				"lodash.truncate": "^4.4.2",
@@ -26589,6 +23722,7 @@
 			"version": "8.16.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"json-schema-traverse": "^1.0.0",
@@ -26604,6 +23738,7 @@
 			"version": "4.3.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -26618,6 +23753,7 @@
 			"version": "2.0.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -26628,17 +23764,20 @@
 		"node_modules/table/node_modules/color-name": {
 			"version": "1.1.4",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/table/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/table/node_modules/slice-ansi": {
 			"version": "4.0.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
@@ -26919,12 +24058,8 @@
 		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
-			"license": "MIT"
-		},
-		"node_modules/third-party-web": {
-			"version": "0.23.4",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/throttleit": {
 			"version": "1.0.1",
@@ -27017,52 +24152,6 @@
 				"node": ">= 4.0.0"
 			}
 		},
-		"node_modules/tr46": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/tree-kill": {
-			"version": "1.2.2",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"tree-kill": "cli.js"
-			}
-		},
-		"node_modules/trim-newlines": {
-			"version": "3.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/trim-repeated": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/trim-repeated/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/ts-api-utils": {
 			"version": "1.3.0",
 			"license": "MIT",
@@ -27145,6 +24234,7 @@
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -27256,14 +24346,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/typedarray-to-buffer": {
-			"version": "3.1.5",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-typedarray": "^1.0.0"
-			}
-		},
 		"node_modules/typescript": {
 			"version": "5.4.5",
 			"license": "Apache-2.0",
@@ -27275,8 +24357,10 @@
 				"node": ">=14.17"
 			}
 		},
-		"node_modules/uc.micro": {
-			"version": "1.0.6",
+		"node_modules/ufo": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+			"integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -27292,15 +24376,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/unbzip2-stream": {
-			"version": "1.4.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer": "^5.2.1",
-				"through": "^2.3.8"
 			}
 		},
 		"node_modules/undici-types": {
@@ -27342,17 +24417,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/unique-string": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"crypto-random-string": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/universalify": {
@@ -27588,11 +24652,6 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
-		"node_modules/v8-compile-cache": {
-			"version": "2.4.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.2.0",
 			"dev": true,
@@ -27622,14 +24681,6 @@
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/valtio": {
@@ -27706,43 +24757,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/w3c-xmlserializer": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"xml-name-validator": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/wait-on": {
-			"version": "7.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"axios": "^1.6.1",
-				"joi": "^17.11.0",
-				"lodash": "^4.17.21",
-				"minimist": "^1.2.8",
-				"rxjs": "^7.8.1"
-			},
-			"bin": {
-				"wait-on": "bin/wait-on"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/wait-on/node_modules/rxjs": {
-			"version": "7.8.1",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.1.0"
-			}
-		},
 		"node_modules/walker": {
 			"version": "1.0.8",
 			"dev": true,
@@ -27777,19 +24791,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"defaults": "^1.0.3"
-			}
-		},
-		"node_modules/web-vitals": {
-			"version": "3.5.2",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
-		"node_modules/webidl-conversions": {
-			"version": "7.0.0",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/webpack": {
@@ -27891,104 +24892,6 @@
 				}
 			}
 		},
-		"node_modules/webpack-cli": {
-			"version": "5.1.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^2.1.1",
-				"@webpack-cli/info": "^2.0.2",
-				"@webpack-cli/serve": "^2.0.5",
-				"colorette": "^2.0.14",
-				"commander": "^10.0.1",
-				"cross-spawn": "^7.0.3",
-				"envinfo": "^7.7.3",
-				"fastest-levenshtein": "^1.0.12",
-				"import-local": "^3.0.2",
-				"interpret": "^3.1.1",
-				"rechoir": "^0.8.0",
-				"webpack-merge": "^5.7.3"
-			},
-			"bin": {
-				"webpack-cli": "bin/cli.js"
-			},
-			"engines": {
-				"node": ">=14.15.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "5.x.x"
-			},
-			"peerDependenciesMeta": {
-				"@webpack-cli/generators": {
-					"optional": true
-				},
-				"webpack-bundle-analyzer": {
-					"optional": true
-				},
-				"webpack-dev-server": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/webpack-cli/node_modules/commander": {
-			"version": "10.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/webpack-cli/node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/webpack-cli/node_modules/shebang-command": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/webpack-cli/node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/webpack-cli/node_modules/which": {
-			"version": "2.0.2",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/webpack-dev-middleware": {
 			"version": "5.3.4",
 			"dev": true,
@@ -28067,62 +24970,6 @@
 				"webpack-cli": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/webpack-merge": {
-			"version": "5.10.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"clone-deep": "^4.0.1",
-				"flat": "^5.0.2",
-				"wildcard": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/webpack-merge/node_modules/clone-deep": {
-			"version": "4.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.2",
-				"shallow-clone": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/webpack-merge/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/webpack-merge/node_modules/kind-of": {
-			"version": "6.0.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/webpack-merge/node_modules/shallow-clone": {
-			"version": "3.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^6.0.2"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/webpack-sources": {
@@ -28256,41 +25103,11 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/whatwg-encoding": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"iconv-lite": "0.6.3"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/whatwg-mimetype": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/whatwg-url": {
-			"version": "11.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "^3.0.0",
-				"webidl-conversions": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/which": {
 			"version": "1.3.1",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -28383,14 +25200,10 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/wildcard": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -28486,27 +25299,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/xdg-basedir": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/xml-name-validator": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/xmlchars": {
-			"version": "2.2.0",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/y-indexeddb": {
 			"version": "9.0.12",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"@wordpress/data": "^9.28.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^5.8.0",
 		"@wordpress/element": "^5.35.0",
-		"10up-toolkit": "^6.2.0",
+		"10up-toolkit": "^6.4.1",
 		"classnames": "^2.5.1",
 		"cypress": "^13.8.1",
 		"cypress-localstorage-commands": "^2.2.5"


### PR DESCRIPTION
This pull request updates the build system for the example plugin by replacing `@wordpress/scripts` with `10up-toolkit` and making related adjustments to configuration files and constants. The changes aim to streamline the development workflow and align with the new toolkit's structure and features.

### Build System Migration:

* Updated `example/package.json` to replace `@wordpress/scripts` with `10up-toolkit` for the `build` and `start` scripts and added a new `10up-toolkit` configuration section for block assets, script modules, entry points, and block directory paths. [[1]](diffhunk://#diff-a593fc14fdef41aaf092f774b92cb74bafeda3e9559f8ae4762374bf4af80c92L7-R8) [[2]](diffhunk://#diff-a593fc14fdef41aaf092f774b92cb74bafeda3e9559f8ae4762374bf4af80c92L24-R38)
* Removed the custom `webpack.config.js` file, as `10up-toolkit` manages the Webpack configuration internally.

### Path and URL Adjustments:

* Updated constants in `example/plugin.php` to replace references to the `build` directory with `dist`, reflecting the new output directory used by `10up-toolkit`.

### Asset Loading Updates:

* Modified the `enqueue_block_editor_scripts` function in `example/plugin.php` to adjust paths for block editor assets, moving from `index.asset.php` and `index.js` to `js/index.asset.php` and `js/index.js`.

### Dependency Updates:

* Updated the `10up-toolkit` dependency version in the main `package.json` file to align with the version used in the example plugin.