### PR TITLE
Add `iconSet` property to the `IconPicker`, `InlineIconPicker`, and `IconPickerToolbarButton` components

### DIFF
--- a/components/icon-picker/icon-picker-toolbar-button.tsx
+++ b/components/icon-picker/icon-picker-toolbar-button.tsx
@@ -16,6 +16,11 @@ interface IconPickerToolbarButtonProps extends IconPickerProps {
 	 * Label for the button
 	 */
 	buttonLabel?: string;
+	/**
+	 * Optionally specify the icon set to use
+	 * If not specified, all icon sets will be used
+	 */
+	iconSet?: string;
 }
 
 export const IconPickerToolbarButton: React.FC<IconPickerToolbarButtonProps> = (props) => {

--- a/components/icon-picker/icon-picker.tsx
+++ b/components/icon-picker/icon-picker.tsx
@@ -200,12 +200,17 @@ export type IconPickerProps = Omit<React.ComponentProps<typeof BaseControl>, 'ch
 	 * Change handler for when a new icon is selected
 	 */
 	onChange: (icon: { name: string; iconSet: string }) => void;
+	/**
+	 * Optionally specify the icon set to use
+	 * If not specified, all icon sets will be used
+	 */
+	iconSet?: string;
 };
 
 export const IconPicker: React.FC<IconPickerProps> = (props) => {
-	const { value, onChange, label = '', ...rest } = props;
+	const { value, onChange, iconSet, label = '', ...rest } = props;
 
-	const icons = useIcons();
+	const icons = useIcons(iconSet ? iconSet : '');
 
 	const instanceId = useInstanceId(IconPicker);
 	const id = `icon-picker-${instanceId}`;

--- a/components/icon-picker/inline-icon-picker.tsx
+++ b/components/icon-picker/inline-icon-picker.tsx
@@ -17,6 +17,11 @@ interface InlineIconPickerProps extends IconPickerProps {
 	 * @param props
 	 */
 	renderToggle: (props: { onToggle: () => void }) => React.JSX.Element;
+	/**
+	 * Optionally specify the icon set to use
+	 * If not specified, all icon sets will be used
+	 */
+	iconSet?: string;
 }
 
 export const IconPickerDropdown: React.FC<InlineIconPickerProps> = (props) => {

--- a/components/icon-picker/readme.md
+++ b/components/icon-picker/readme.md
@@ -48,4 +48,9 @@ export function BlockEdit(props) {
 
 _The recommended approach for adding an icon picker to your custom block is using the `InlineIconPicker` as it delivers the best user experience._
 
-In order to add icons to become available to the icon picker you need to use the [`registerIcons`](../../api/register-icons/) function.
+In order to add icons to become available to the icon picker you need to use the
+[`registerIcons`](../../api/register-icons/) function.
+
+You can optionally include the `iconSet` property to the `IconPicker`,
+`InlineIconPicker`, and `IconPickerToolbarButton` to limit the icons available
+in the picker if necessary.

--- a/example/src/blocks/icon-picker-example/block.json
+++ b/example/src/blocks/icon-picker-example/block.json
@@ -15,6 +15,13 @@
 			"default": {
 				"iconSet": "example/theme",
 				"name": "cloud"
+			},
+			"limitedPaletteIcon": {
+				"type": "object",
+				"default": {
+					"iconSet": "example/limited-palette",
+					"name": "brush-5"
+				}
 			}
 		}
 	},

--- a/example/src/blocks/icon-picker-example/edit.tsx
+++ b/example/src/blocks/icon-picker-example/edit.tsx
@@ -9,13 +9,15 @@ import {
     InlineIconPicker,
 } from '@10up/block-components';
 
+const limitedPaletteIconSet = 'example/limited-palette';
+
 export function BlockEdit(props) {
     const {
         attributes,
         setAttributes
     } = props;
 
-    const { icon } = attributes;
+    const { icon, limitedPaletteIcon } = attributes;
     const blockProps = useBlockProps();
 
     const handleIconSelection = (value: {
@@ -23,16 +25,27 @@ export function BlockEdit(props) {
         iconSet: string;
     }) => setAttributes({icon: { name: value.name, iconSet: value.iconSet }});
 
+    const handleLPIconSelection = (value: {
+        name: string;
+        iconSet: string;
+    }) => setAttributes({limitedPaletteIcon: { name: value.name, iconSet: value.iconSet }});
+
     return (
         <>
             <BlockControls>
                 <ToolbarGroup>
                     <IconPickerToolbarButton value={icon} onChange={handleIconSelection} />
                 </ToolbarGroup>
+                <ToolbarGroup>
+                    <IconPickerToolbarButton value={limitedPaletteIcon} onChange={handleLPIconSelection} iconSet={limitedPaletteIconSet} label="Select Limited Palette Icon" />
+                </ToolbarGroup>
             </BlockControls>
             <InspectorControls>
                 <PanelBody title={__('Icon Settings')}>
                     <IconPicker value={icon} onChange={handleIconSelection} />
+                </PanelBody>
+                <PanelBody title={__('Limited Palette Icon Settings')}>
+                    <IconPicker value={limitedPaletteIcon} onChange={handleLPIconSelection} iconSet={limitedPaletteIconSet} />
                 </PanelBody>
             </InspectorControls>
             <div {...blockProps}>
@@ -42,7 +55,10 @@ export function BlockEdit(props) {
                         width: 60px;
                     }`}
                 </style>
+                <p>Icon chosen from entire icon set:</p>
                 <InlineIconPicker value={icon} onChange={handleIconSelection} className="icon-preview"/>
+                <p>Icon chosen from limited icon set:</p>
+                <InlineIconPicker value={limitedPaletteIcon} onChange={handleLPIconSelection} iconSet={limitedPaletteIconSet} className="icon-preview"/>
                 <h2 style={{marginTop: '0'}}>Hello World!</h2>
             </div>
         </>

--- a/example/src/blocks/icon-picker-example/register-icons.tsx
+++ b/example/src/blocks/icon-picker-example/register-icons.tsx
@@ -46,6 +46,63 @@ import { renderToString } from '@wordpress/element';
 import { registerIcons } from '@10up/block-components';
 
 registerIcons({
+    name: 'example/limited-palette',
+    label: "Example",
+    icons: [
+        {
+            source: renderToString( <CoreIcon icon={arrowDown} />),
+            name: "arrowDown-5",
+            label: "arrowDown"
+        },
+        {
+            source: renderToString( <CoreIcon icon={arrowLeft} />),
+            name: "arrowLeft-5",
+            label: "arrowLeft"
+        },
+        {
+            source: renderToString( <CoreIcon icon={arrowRight} />),
+            name: "arrowRight-5",
+            label: "arrowRight"
+        },
+        {
+            source: renderToString( <CoreIcon icon={arrowUp} />),
+            name: "arrowUp-5",
+            label: "arrowUp"
+        },
+        {
+            source: renderToString( <CoreIcon icon={aspectRatio} />),
+            name: "aspectRatio-5",
+            label: "aspectRatio"
+        },
+        {
+            source: renderToString( <CoreIcon icon={atSymbol} />),
+            name: "atSymbol-5",
+            label: "atSymbol"
+        },
+        {
+            source: renderToString( <CoreIcon icon={audio} />),
+            name: "audio-5",
+            label: "audio"
+        },
+        {
+            source: renderToString( <CoreIcon icon={backup} />),
+            name: "backup-5",
+            label: "backup"
+        },
+        {
+            source: renderToString( <CoreIcon icon={blockTable} />),
+            name: "blockTable-5",
+            label: "blockTable"
+        },
+        {
+            source: renderToString( <CoreIcon icon={brush} />),
+            name: "brush-5",
+            label: "brush"
+        },
+    ]
+})
+
+registerIcons({
     name: 'example/theme',
     label: "Example",
     icons: [

--- a/hooks/use-icons/index.ts
+++ b/hooks/use-icons/index.ts
@@ -27,14 +27,14 @@ const useIcons = (iconSet = '') => {
 	useEffect(() => {
 		if (iconSet) {
 			setIcons(transformIcons(rawIcons as IconSet));
+		} else {
+			setIcons(
+				Object.values(rawIcons).reduce(
+					(rawIcons, iconSet) => [...rawIcons, ...transformIcons(iconSet)],
+					[],
+				),
+			);
 		}
-
-		setIcons(
-			Object.values(rawIcons).reduce(
-				(rawIcons, iconSet) => [...rawIcons, ...transformIcons(iconSet)],
-				[],
-			),
-		);
 	}, [rawIcons, iconSet]);
 
 	return icons;


### PR DESCRIPTION
### Description of the Change
Allows developers to specify an an `iconSet` property when using the IconPicker components (`IconPicker`, `InlineIconPicker`, and `IconPickerToolbarButton`). Includes an updated example block that uses those components with both unlimited & limited icon sets.

### How to test the Change
Use the updated example to test the change.

### Changelog Entry
> Added - `iconSet` property to the `IconPicker`, `InlineIconPicker`, and `IconPickerToolbarButton` components

### Checklist:
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

Not sure if tests need to be written here. Would love help with that if so.