### PR TITLE
Fix: Missing renamed instance of `clsx` function in counter component

### DIFF
--- a/components/counter/index.tsx
+++ b/components/counter/index.tsx
@@ -169,7 +169,7 @@ const Counter: ForwardRefExoticComponent<
 	return (
 		<StyledComponentContext cacheKey="tenup-component-counter">
 			<StyledCounter
-				className={cx('tenup--block-components__character-count', {
+				className={clsx('tenup--block-components__character-count', {
 					'is-over-limit': count > limit,
 				})}
 				ref={ref}


### PR DESCRIPTION
This pull request includes a small change to the `components/counter/index.tsx` file. The change replaces the usage of the `cx` utility with `clsx` for managing class names in the `className` property of the `StyledCounter` component.