### PR TITLE
Fix: allow passing aria label to link

### DIFF
--- a/components/link/index.tsx
+++ b/components/link/index.tsx
@@ -104,6 +104,7 @@ interface LinkProps {
 	kind?: string;
 	placeholder?: string;
 	className?: string;
+	ariaLabel?: string;
 }
 
 /*
@@ -123,6 +124,7 @@ export const Link: FC<LinkProps> = ({
 	kind = '',
 	placeholder = __('Link text ...', '10up-block-components'),
 	className = undefined,
+	ariaLabel = undefined,
 	...rest
 }) => {
 	const [isPopoverVisible, setIsPopoverVisible] = useState(false);
@@ -155,7 +157,7 @@ export const Link: FC<LinkProps> = ({
 				className={clsx('tenup-block-components-link__label', className)}
 				value={value}
 				onChange={onTextChange}
-				aria-label={__('Link text', '10up-block-components')}
+				aria-label={ariaLabel || value || __('Link text', '10up-block-components')}
 				placeholder={placeholder}
 				__unstablePastePlainText
 				allowedFormats={[]}

--- a/components/link/readme.md
+++ b/components/link/readme.md
@@ -37,6 +37,7 @@ const BlockEdit = (props) => {
                 onLinkRemove={ handleLinkRemove }
                 className='example-classname'
                 placeholder='Enter Link Text here...'
+                ariaLabel='Read more about our services'
             />
         </div>
     )
@@ -59,4 +60,5 @@ The `<RichText>` node will only render when BlockEdit is selected.
 |  `kind` | `string` | `""` |        Page or Post |
 |  `placeholder` | `string` | `Link text ...` |      Text visible before actual value is inserted |
 |  `className` | `string` | `undefined` |          html class to be applied to the anchor element |
+|  `ariaLabel` | `string` | `undefined` |          Custom aria-label for accessibility. Defaults to the link text (value) if not provided |
 |  `...rest` | `object` | `{}` | pass through any additional props to the RichText component used for the link element |


### PR DESCRIPTION
This pull request enhances the `Link` component by adding support for a custom `ariaLabel` prop to improve accessibility. The changes include updates to the component's implementation, its usage in the documentation, and the README file.

### Accessibility Improvements:

* [`components/link/index.tsx`](diffhunk://#diff-a7a1ed347e6ed489eae5fda992a13470406489cc252cd7e91af70d905d03d0ddR107): Added a new `ariaLabel` prop to the `LinkProps` interface and its default value in the `Link` component. The `aria-label` attribute now uses the `ariaLabel` prop, falling back to the link text or a default value if not provided. [[1]](diffhunk://#diff-a7a1ed347e6ed489eae5fda992a13470406489cc252cd7e91af70d905d03d0ddR107) [[2]](diffhunk://#diff-a7a1ed347e6ed489eae5fda992a13470406489cc252cd7e91af70d905d03d0ddR127) [[3]](diffhunk://#diff-a7a1ed347e6ed489eae5fda992a13470406489cc252cd7e91af70d905d03d0ddL158-R160)

### Documentation Updates:

* [`components/link/readme.md`](diffhunk://#diff-6b8ccb086137085aa84307d434cd21b49ab15cbaeb3da56ecff0d81dbd97484aR40): Updated the example usage of the `Link` component to include the new `ariaLabel` prop. Added a description of the `ariaLabel` prop to the README table, specifying its purpose and default behavior. [[1]](diffhunk://#diff-6b8ccb086137085aa84307d434cd21b49ab15cbaeb3da56ecff0d81dbd97484aR40) [[2]](diffhunk://#diff-6b8ccb086137085aa84307d434cd21b49ab15cbaeb3da56ecff0d81dbd97484aR63)

Closes #137 