### PR TITLE
Fix: Include Exports for Require

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,18 @@
 			"import": {
 				"types": "./dist/index.d.ts",
 				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
 			}
 		},
 		"./api/*": {
 			"import": {
+				"types": "./dist/api/*/index.d.ts",
+				"default": "./dist/api/*/index.js"
+			},
+			"require": {
 				"types": "./dist/api/*/index.d.ts",
 				"default": "./dist/api/*/index.js"
 			}
@@ -25,16 +33,28 @@
 			"import": {
 				"types": "./dist/components/*/index.d.ts",
 				"default": "./dist/components/*/index.js"
+			},
+			"require": {
+				"types": "./dist/components/*/index.d.ts",
+				"default": "./dist/components/*/index.js"
 			}
 		},
 		"./hooks/*": {
 			"import": {
 				"types": "./dist/hooks/*/index.d.ts",
 				"default": "./dist/hooks/*/index.js"
+			},
+			"require": {
+				"types": "./dist/hooks/*/index.d.ts",
+				"default": "./dist/hooks/*/index.js"
 			}
 		},
 		"./stores/*": {
 			"import": {
+				"types": "./dist/stores/*/index.d.ts",
+				"default": "./dist/stores/*/index.js"
+			},
+			"require": {
 				"types": "./dist/stores/*/index.d.ts",
 				"default": "./dist/stores/*/index.js"
 			}


### PR DESCRIPTION
This pull request updates the `package.json` file to add support for the `require` field alongside the existing `import` field, ensuring compatibility with CommonJS modules. The changes apply to several paths, including the main entry point and specific subdirectories like `api`, `components`, `hooks`, and `stores`.

### Compatibility updates:

* Added `require` field to the main entry point, specifying both `types` and `default` paths for CommonJS compatibility. (`[package.jsonR16-R59](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R16-R59)`)
* Extended the `require` field to subdirectory paths (`api`, `components`, `hooks`, and `stores`), ensuring consistent support for CommonJS modules across the project. (`[package.jsonR16-R59](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R16-R59)`)