### PR TITLE
Content Picker: Retrieve content in view context

### DIFF
--- a/components/content-picker/SortableList.tsx
+++ b/components/content-picker/SortableList.tsx
@@ -113,7 +113,7 @@ const SortableList: React.FC<SortableListProps> = ({
 					entityKind,
 					item.type,
 					item.id,
-					{ _fields: fields },
+					{ _fields: fields, context: 'view' },
 				] as const;
 				const result = getEntityRecord<Post | Term | User>(...getEntityRecordParameters);
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Limit the response for the content picker and make it possible to display content a user cannot edit but view.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #390

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed - Display items in content picker a user cannot edit but view

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ocean90

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
