### PR TITLE
Add useRenderAppenderWithLimit hook

### DIFF
--- a/example/src/blocks/inner-blocks-limit/block.json
+++ b/example/src/blocks/inner-blocks-limit/block.json
@@ -1,0 +1,17 @@
+{
+  "name": "example/inner-block-limit",
+  "apiVersion": 3,
+  "title": "Inner Block Limit - Example",
+  "description": "Example Block to show the usage of the useRenderAppenderWithLimit hook",
+  "icon": "smiley",
+  "category": "common",
+  "example": {},
+  "supports": {
+    "html": false
+  },
+  "attributes": {},
+  "allowedBlocks": [
+    "example/hello-world"
+  ],
+  "editorScript": "file:./index.ts"
+}

--- a/example/src/blocks/inner-blocks-limit/edit.tsx
+++ b/example/src/blocks/inner-blocks-limit/edit.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { useRenderAppenderWithLimit } from '@10up/block-components';
+
+const TEMPLATE = [
+	[
+		'example/hello-world',
+		{},
+	],
+];
+
+export const BlockEdit = () => {
+	const renderAppender = useRenderAppenderWithLimit(4);
+	const blockProps = useBlockProps();
+
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			template: TEMPLATE,
+			renderAppender,
+		},
+	);
+
+	return (
+		<div {...blockProps}>
+			<div {...innerBlocksProps} />
+		</div>
+	);
+};

--- a/example/src/blocks/inner-blocks-limit/index.tsx
+++ b/example/src/blocks/inner-blocks-limit/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+import { BlockEdit } from './edit';
+import metadata from './block.json';
+
+registerBlockType(metadata, {
+	edit: BlockEdit,
+	save: () => <InnerBlocks.Content />
+});

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -18,3 +18,4 @@ export { usePostMetaValue } from './use-post-meta-value';
 export { useTaxonomy } from './use-taxonomy';
 export { useIsSupportedMetaField } from './use-is-supported-meta-value';
 export { useFlatInnerBlocks } from './use-flat-inner-blocks';
+export { useRenderAppenderWithLimit } from './use-render-appender-with-limit';

--- a/hooks/use-render-appender-with-limit/index.ts
+++ b/hooks/use-render-appender-with-limit/index.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useSelect } from '@wordpress/data';
 import {
 	store as blockEditorStore,
@@ -5,11 +6,11 @@ import {
 	InnerBlocks,
 } from '@wordpress/block-editor';
 
-export function useRenderAppenderWithLimit(limit: number, buttonAppender = false) {
+export function useRenderAppenderWithLimit(
+	limit: number,
+	appender: React.ComponentType = InnerBlocks.DefaultBlockAppender,
+) {
 	const { clientId } = useBlockEditContext();
-	const appenderType = buttonAppender
-		? InnerBlocks.ButtonBlockAppender
-		: InnerBlocks.DefaultBlockAppender;
 
 	return useSelect(
 		(select) => {
@@ -17,7 +18,7 @@ export function useRenderAppenderWithLimit(limit: number, buttonAppender = false
 			const { innerBlocks } = select(blockEditorStore).getBlock(clientId);
 			const numberOfInnerBlocks = innerBlocks.length;
 			const shouldRenderAppender = numberOfInnerBlocks < limit;
-			return shouldRenderAppender ? appenderType : false;
+			return shouldRenderAppender ? appender : false;
 		},
 		[clientId, limit],
 	);

--- a/hooks/use-render-appender-with-limit/index.ts
+++ b/hooks/use-render-appender-with-limit/index.ts
@@ -1,0 +1,24 @@
+import { useSelect } from '@wordpress/data';
+import {
+	store as blockEditorStore,
+	useBlockEditContext,
+	InnerBlocks,
+} from '@wordpress/block-editor';
+
+export function useRenderAppenderWithLimit(limit: number, buttonAppender = false) {
+	const { clientId } = useBlockEditContext();
+	const appenderType = buttonAppender
+		? InnerBlocks.ButtonBlockAppender
+		: InnerBlocks.DefaultBlockAppender;
+
+	return useSelect(
+		(select) => {
+			// @ts-expect-error - TS doesn't know about the block editor store
+			const { innerBlocks } = select(blockEditorStore).getBlock(clientId);
+			const numberOfInnerBlocks = innerBlocks.length;
+			const shouldRenderAppender = numberOfInnerBlocks < limit;
+			return shouldRenderAppender ? appenderType : false;
+		},
+		[clientId, limit],
+	);
+}

--- a/hooks/use-render-appender-with-limit/readme.md
+++ b/hooks/use-render-appender-with-limit/readme.md
@@ -1,0 +1,31 @@
+# `useRenderAppenderWithLimit`
+
+There are times when we need more granular control over how many blocks can be added to a block that supports inner blocks. That’s where the `useRenderAppenderWithLimit` custom hook comes in. With a single line of code, it gives us an easy way to enforce a maximum number of inner blocks.
+
+The hook will return either false or the block appender, depending on the maximum limit you pass in. Behind the scenes, it handles the heavy lifting by fetching and counting the inner blocks for your block, then conditionally returning the appender only when allowed.
+
+## Usage
+
+```js
+import { useBlockProps, useInnerBlockProps } from '@wordpress/block-editor';
+import { useRenderAppenderWithLimit } from '@10up/block-components';
+
+function BlockEdit() {
+	const renderAppender = useRenderAppenderWithLimit(4);
+
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			...
+			renderAppender,
+		},
+	);
+
+	return (
+		<div {...useBlockProps}>
+			<div {...innerBlocksProps}>
+		</div>
+	);
+}
+```

--- a/hooks/use-render-appender-with-limit/readme.md
+++ b/hooks/use-render-appender-with-limit/readme.md
@@ -4,8 +4,14 @@ There are times when we need more granular control over how many blocks can be a
 
 The hook will return either false or the block appender, depending on the maximum limit you pass in. Behind the scenes, it handles the heavy lifting by fetching and counting the inner blocks for your block, then conditionally returning the appender only when allowed.
 
+## Parameters
+
+- **`limit`** (`number`): The maximum number of inner blocks allowed. When the current number of inner blocks reaches this limit, the appender will not be rendered.
+- **`appender`** (`React.ComponentType`, optional): The React component to render as the block appender when under the limit. Defaults to `InnerBlocks.DefaultBlockAppender` if not provided.
+
 ## Usage
 
+**Default**
 ```js
 import { useBlockProps, useInnerBlockProps } from '@wordpress/block-editor';
 import { useRenderAppenderWithLimit } from '@10up/block-components';
@@ -23,9 +29,79 @@ function BlockEdit() {
 	);
 
 	return (
-		<div {...useBlockProps}>
+		<div {...blockProps}>
 			<div {...innerBlocksProps}>
 		</div>
 	);
 }
 ```
+
+**Button Type Appender**
+```js
+import { useBlockProps, useInnerBlocksProps, ButtonBlockAppender } from '@wordpress/block-editor';
+import { useRenderAppenderWithLimit } from '@10up/block-components';
+
+function BlockEdit(props) {
+	const { clientId } = props;
+	const renderAppender = useRenderAppenderWithLimit(4, () => <ButtonBlockAppender rootClientId={clientId} />);
+
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			...
+			renderAppender,
+		},
+	);
+
+	return (
+		<div {...blockProps}>
+			<div {...innerBlocksProps}>
+		</div>
+	);
+}
+```
+> [!NOTE]
+> For appenders that require props (like `ButtonBlockAppender` needing `rootClientId`), pass a function component that returns the appender with the required props.
+
+**Custom Appender**
+```js
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
+import { useRenderAppenderWithLimit } from '@10up/block-components';
+import { __ } from '@wordpress/i18n';
+
+// Custom appender component
+function CustomAppender({ children, ...props }) {
+	return (
+		<div className="custom-appender" {...props}>
+			<Button variant="secondary" className="custom-add-button">
+				{__('+ Add New Block', 'text-domain')}
+			</Button>
+			{children}
+		</div>
+	);
+}
+
+function BlockEdit() {
+	const renderAppender = useRenderAppenderWithLimit(4, CustomAppender);
+
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			...
+			renderAppender,
+		},
+	);
+
+	return (
+		<div {...blockProps}>
+			<div {...innerBlocksProps}>
+		</div>
+	);
+}
+```
+
+> [!NOTE]
+> For a fully functional custom appender that can actually add blocks, you would need to implement the block insertion logic using WordPress's `useBlockEditor` hook or similar APIs. The example above shows the structure, but in practice, you'd typically use one of WordPress's built-in appenders like `ButtonBlockAppender` or `DefaultBlockAppender` for functionality.


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This pull request introduces a new custom React hook, `useRenderAppenderWithLimit`, which allows developers to easily enforce a maximum number of inner blocks in WordPress blocks. It also demonstrates its usage by adding an example block and updates the block components package to export the new hook.

**New Hook Implementation and Documentation**

* Added `useRenderAppenderWithLimit` hook in `hooks/use-render-appender-with-limit/index.ts`, which conditionally returns a block appender based on the number of inner blocks and a specified limit.
* Provided documentation for the hook in `hooks/use-render-appender-with-limit/readme.md`, including usage instructions and an example.

**Example Block Demonstrating the Hook**

* Created a new block, `example/inner-block-limit`, with configuration in `example/src/blocks/inner-blocks-limit/block.json` to showcase usage of the hook.
* Implemented the block edit component in `example/src/blocks/inner-blocks-limit/edit.tsx`, utilizing the hook to limit inner blocks to four.
* Registered the block in `example/src/blocks/inner-blocks-limit/index.tsx`, wiring up the edit and save functionality.

**Package Export Update**

* Exported `useRenderAppenderWithLimit` from the main hooks index for easier import throughout the codebase.
<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/block-components/issues/393

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New Hook

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ncoetzer @fabiankaegy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
