### PR TITLE
Add control over including embeds in search response in ContentSearch and ContentPicker

### DIFF
--- a/components/content-picker/index.tsx
+++ b/components/content-picker/index.tsx
@@ -11,6 +11,7 @@ import { StyledComponentContext } from '../styled-components-context';
 import { defaultRenderItemType } from '../content-search/SearchItem';
 import {
 	ContentSearchMode,
+	QueryArgs,
 	QueryFilter,
 	QueryFieldsFilter,
 	RenderItemComponentProps,
@@ -64,6 +65,7 @@ export interface ContentPickerProps {
 	queryFieldsFilter?: QueryFieldsFilter;
 	searchResultFilter?: SearchResultFilter;
 	pickedItemFilter?: PickedItemFilter;
+	includeEmbeds?: QueryArgs['includeEmbeds'];
 	maxContentItems?: number;
 	isOrderable?: boolean;
 	singlePickedLabel?: string;
@@ -92,6 +94,7 @@ export const ContentPicker: React.FC<ContentPickerProps> = ({
 	queryFieldsFilter,
 	searchResultFilter,
 	pickedItemFilter,
+	includeEmbeds,
 	maxContentItems = 1,
 	isOrderable = false,
 	singlePickedLabel = __('You have selected the following item:', '10up-block-components'),
@@ -173,6 +176,7 @@ export const ContentPicker: React.FC<ContentPickerProps> = ({
 						queryFilter={queryFilter}
 						queryFieldsFilter={queryFieldsFilter}
 						searchResultFilter={searchResultFilter}
+						includeEmbeds={includeEmbeds}
 						perPage={perPage}
 						fetchInitialResults={fetchInitialResults}
 						renderItemType={renderItemType}

--- a/components/content-search/index.tsx
+++ b/components/content-search/index.tsx
@@ -83,6 +83,7 @@ export interface ContentSearchProps {
 	queryFilter?: QueryFilter;
 	queryFieldsFilter?: QueryFieldsFilter;
 	searchResultFilter?: SearchResultFilter;
+	includeEmbeds?: boolean;
 	excludeItems?: Array<IdentifiableObject>;
 	renderItemType?: (props: NormalizedSuggestion) => string;
 	renderItem?: (props: RenderItemComponentProps) => JSX.Element;
@@ -109,6 +110,7 @@ const ContentSearch: React.FC<ContentSearchProps> = ({
 	queryFilter = (query: string) => query,
 	queryFieldsFilter,
 	searchResultFilter,
+	includeEmbeds = false,
 	excludeItems = [],
 	renderItemType = undefined,
 	renderItem: SearchResultItem = SearchItem,
@@ -144,6 +146,7 @@ const ContentSearch: React.FC<ContentSearchProps> = ({
 				queryFilter,
 				queryFieldsFilter,
 				searchResultFilter,
+				includeEmbeds,
 			],
 			queryFn: async ({ pageParam = 1, signal }) =>
 				fetchSearchResults({
@@ -155,6 +158,7 @@ const ContentSearch: React.FC<ContentSearchProps> = ({
 					queryFilter,
 					queryFieldsFilter,
 					searchResultFilter,
+					includeEmbeds,
 					excludeItems,
 					signal,
 				}),

--- a/components/content-search/index.tsx
+++ b/components/content-search/index.tsx
@@ -9,6 +9,7 @@ import { StyledComponentContext } from '../styled-components-context';
 import type {
 	ContentSearchMode,
 	IdentifiableObject,
+	QueryArgs,
 	QueryFilter,
 	QueryFieldsFilter,
 	RenderItemComponentProps,
@@ -83,7 +84,7 @@ export interface ContentSearchProps {
 	queryFilter?: QueryFilter;
 	queryFieldsFilter?: QueryFieldsFilter;
 	searchResultFilter?: SearchResultFilter;
-	includeEmbeds?: boolean;
+	includeEmbeds?: QueryArgs['includeEmbeds'];
 	excludeItems?: Array<IdentifiableObject>;
 	renderItemType?: (props: NormalizedSuggestion) => string;
 	renderItem?: (props: RenderItemComponentProps) => JSX.Element;

--- a/components/content-search/readme.md
+++ b/components/content-search/readme.md
@@ -79,3 +79,33 @@ function MyComponent( props ) {
 | `renderItem`          | `function` | `undefined`                          | Function to customize the rendering of each search result item. Receives `RenderItemComponentProps` and must return a JSX element. |
 | `fetchInitialResults` | `bool`     | `false`                              | Fetch initial results to present when focusing the search input                                                                  |
 | `options.inputDelay`  | `number`   | `undefined`                           | Debounce delay passed to the internal search input, defaults to 350ms                                                             |
+
+## Search Result Item Customization
+
+There are a number of vectors for customizing how search results are rendered. You can customize the item type label (e.g. "Post", "Page", "Category") by passing a function to the `renderItemType` prop. This function returns a string and receives a single `suggestion` argument, an object with the following shape:
+
+```js
+{
+	id: number;
+	subtype: string;
+	title: string;
+	type: string;
+	url: string;
+	embedded?: object;
+}
+```
+
+You can also customize the entire item by passing a function to the `renderItem` prop. This function should be a React component that receives these props:
+
+```js
+{
+    item: object; // The suggestion object (see above).
+    onSelect: () => void;
+    searchTerm: string;
+    id: string;
+    contentTypes: string[];
+    renderType: ( suggestion: object ) => string;
+}
+```
+
+You may need more than the default suggestion fields to render your custom item. The search endpoint is limited (by design) in what fields it returns, but you can use the linking & embedding functionality of the REST API to include the entire post object (or term, or user) in the response via the `embedded` prop. To do this, pass the `includeEmbeds` prop, which can be a boolean (to include all embeds), a string (to include a single embed type), or an array of strings (to include multiple embed types). This is useful if you want to display additional information about a post, such as its publication date. See the [content search example](example/src/blocks/content-search-example/edit.tsx) for a demonstration of this in action.

--- a/components/content-search/readme.md
+++ b/components/content-search/readme.md
@@ -67,6 +67,7 @@ function MyComponent( props ) {
 | `queryFilter`         | `function` | `(query, parametersObject) => query` | Function called to allow you to customize the query before it's made. It's advisable to use `useCallback` to save this parameter |
 | `queryFieldsFilter`   | `function` | `undefined`                          | Function to customize which fields are fetched from the API. Receives `(fields: string[], mode: ContentSearchMode) => string[]`. It's advisable to use `useCallback` to save this parameter. |
 | `searchResultFilter`  | `function` | `undefined`                          | Function to customize the normalized search result item. Receives `(item: NormalizedSuggestion, originalResult: WP_REST_API_Search_Result \| WP_REST_API_User) => NormalizedSuggestion`. It's advisable to use `useCallback` to save this parameter. |
+| `includeEmbeds`       | `bool, string, array` | `undefined` | Whether to include embedded items in the search results. A string or array of strings can be passed to specify the specific embeds. |
 | `label`               | `string`   | `''`                                 | Renders a label for the Search Field.
 | `hideLabelFromVision` | `bool`     | `true`                               | Whether to hide the label                                                                                           |
 | `mode`                | `string`   | `'post'`                             | One of: `post`, `user`, `term`                                                                                                   |

--- a/components/content-search/types.ts
+++ b/components/content-search/types.ts
@@ -31,7 +31,7 @@ export interface QueryArgs {
 	contentTypes: Array<string>;
 	mode: ContentSearchMode;
 	keyword: string;
-	includeEmbeds?: boolean;
+	includeEmbeds?: boolean | string | Array<string>;
 }
 
 export type QueryFilter = (query: string, args: QueryArgs) => string;

--- a/components/content-search/types.ts
+++ b/components/content-search/types.ts
@@ -31,6 +31,7 @@ export interface QueryArgs {
 	contentTypes: Array<string>;
 	mode: ContentSearchMode;
 	keyword: string;
+	includeEmbeds?: boolean;
 }
 
 export type QueryFilter = (query: string, args: QueryArgs) => string;

--- a/components/content-search/utils.ts
+++ b/components/content-search/utils.ts
@@ -16,6 +16,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import type {
 	ContentSearchMode,
+	QueryArgs,
 	QueryFilter,
 	QueryFieldsFilter,
 	SearchResultFilter,
@@ -50,7 +51,7 @@ interface PrepareSearchQueryArgs {
 	contentTypes: Array<string>;
 	queryFilter: QueryFilter;
 	queryFieldsFilter?: QueryFieldsFilter;
-	includeEmbeds?: boolean;
+	includeEmbeds?: QueryArgs['includeEmbeds'];
 }
 
 /*
@@ -93,7 +94,7 @@ export const prepareSearchQuery = ({
 		case 'user':
 			searchQuery = addQueryArgs('wp/v2/users', {
 				search: keyword,
-				...(includeEmbeds ? { _embed: true } : {}),
+				...(includeEmbeds ? { _embed: includeEmbeds } : {}),
 				_fields: fields,
 			});
 			break;
@@ -102,7 +103,7 @@ export const prepareSearchQuery = ({
 				search: keyword,
 				subtype: contentTypes.join(','),
 				type: mode,
-				...(includeEmbeds ? { _embed: true } : {}),
+				...(includeEmbeds ? { _embed: includeEmbeds } : {}),
 				per_page: perPage,
 				page,
 				_fields: fields,
@@ -126,7 +127,7 @@ interface NormalizeResultsArgs {
 	results: WP_REST_API_Search_Result[] | WP_REST_API_User[];
 	excludeItems: Array<IdentifiableObject>;
 	searchResultFilter?: SearchResultFilter;
-	includeEmbeds?: boolean;
+	includeEmbeds?: QueryArgs['includeEmbeds'];
 }
 
 /**
@@ -222,7 +223,7 @@ interface FetchSearchResultsArgs {
 	queryFilter: QueryFilter;
 	queryFieldsFilter?: QueryFieldsFilter;
 	searchResultFilter?: SearchResultFilter;
-	includeEmbeds?: boolean;
+	includeEmbeds?: QueryArgs['includeEmbeds'];
 	excludeItems: Array<IdentifiableObject>;
 	signal?: AbortSignal;
 }

--- a/components/content-search/utils.ts
+++ b/components/content-search/utils.ts
@@ -78,6 +78,13 @@ export const prepareSearchQuery = ({
 		fields = queryFieldsFilter(fields, mode);
 	}
 
+	if (!fields.includes('_links')) {
+		fields.push('_links');
+	}
+	if (!fields.includes('_embedded')) {
+		fields.push('_embedded');
+	}
+
 	switch (mode) {
 		case 'user':
 			searchQuery = addQueryArgs('wp/v2/users', {

--- a/components/content-search/utils.ts
+++ b/components/content-search/utils.ts
@@ -148,6 +148,7 @@ export const normalizeResults = ({
 	type: ContentSearchMode | string;
 	url: string;
 	info?: string;
+	embedded?: WP_REST_API_Search_Result['_embedded'] | WP_REST_API_User['_embedded'];
 }> => {
 	const filteredResults = filterOutExcludedItems({ results, excludeItems });
 	return filteredResults.map((item) => {
@@ -158,6 +159,7 @@ export const normalizeResults = ({
 			type: ContentSearchMode | string;
 			url: string;
 			info?: string;
+			embedded?: WP_REST_API_Search_Result['_embedded'] | WP_REST_API_User['_embedded'];
 		};
 
 		switch (mode) {
@@ -169,6 +171,7 @@ export const normalizeResults = ({
 					title: toPlainTextTitle(userItem.name),
 					type: mode,
 					url: userItem.link,
+					embedded: userItem._embedded,
 				};
 				break;
 			default:
@@ -179,6 +182,7 @@ export const normalizeResults = ({
 					title: toPlainTextTitle(searchItem.title),
 					type: searchItem.type,
 					url: searchItem.url,
+					embedded: searchItem._embedded,
 				};
 				break;
 		}

--- a/components/content-search/utils.ts
+++ b/components/content-search/utils.ts
@@ -50,6 +50,7 @@ interface PrepareSearchQueryArgs {
 	contentTypes: Array<string>;
 	queryFilter: QueryFilter;
 	queryFieldsFilter?: QueryFieldsFilter;
+	includeEmbeds?: boolean;
 }
 
 /*
@@ -63,6 +64,7 @@ export const prepareSearchQuery = ({
 	contentTypes,
 	queryFilter,
 	queryFieldsFilter,
+	includeEmbeds = false,
 }: PrepareSearchQueryArgs): string => {
 	let searchQuery;
 
@@ -78,17 +80,20 @@ export const prepareSearchQuery = ({
 		fields = queryFieldsFilter(fields, mode);
 	}
 
-	if (!fields.includes('_links')) {
-		fields.push('_links');
-	}
-	if (!fields.includes('_embedded')) {
-		fields.push('_embedded');
+	if (includeEmbeds) {
+		if (!fields.includes('_links')) {
+			fields.push('_links');
+		}
+		if (!fields.includes('_embedded')) {
+			fields.push('_embedded');
+		}
 	}
 
 	switch (mode) {
 		case 'user':
 			searchQuery = addQueryArgs('wp/v2/users', {
 				search: keyword,
+				...(includeEmbeds ? { _embed: true } : {}),
 				_fields: fields,
 			});
 			break;
@@ -97,7 +102,7 @@ export const prepareSearchQuery = ({
 				search: keyword,
 				subtype: contentTypes.join(','),
 				type: mode,
-				_embed: true,
+				...(includeEmbeds ? { _embed: true } : {}),
 				per_page: perPage,
 				page,
 				_fields: fields,
@@ -112,6 +117,7 @@ export const prepareSearchQuery = ({
 		contentTypes,
 		mode,
 		keyword,
+		includeEmbeds,
 	});
 };
 
@@ -120,6 +126,7 @@ interface NormalizeResultsArgs {
 	results: WP_REST_API_Search_Result[] | WP_REST_API_User[];
 	excludeItems: Array<IdentifiableObject>;
 	searchResultFilter?: SearchResultFilter;
+	includeEmbeds?: boolean;
 }
 
 /**
@@ -136,7 +143,7 @@ export const toPlainTextTitle = (input: string | undefined | null): string => {
 	const doc = new DOMParser().parseFromString(String(input), 'text/html');
 	const text = doc.body.textContent ?? '';
 
-	return decodeEntities(text).replace(/\u00A0/g, ' ').trim();
+	return decodeEntities(text).replace(/ /g, ' ').trim();
 };
 
 /*
@@ -148,6 +155,7 @@ export const normalizeResults = ({
 	results,
 	excludeItems,
 	searchResultFilter,
+	includeEmbeds = false,
 }: NormalizeResultsArgs): Array<{
 	id: number;
 	subtype: ContentSearchMode | string;
@@ -178,7 +186,7 @@ export const normalizeResults = ({
 					title: toPlainTextTitle(userItem.name),
 					type: mode,
 					url: userItem.link,
-					embedded: userItem._embedded,
+					...(includeEmbeds ? { embedded: userItem._embedded } : {}),
 				};
 				break;
 			default:
@@ -189,7 +197,7 @@ export const normalizeResults = ({
 					title: toPlainTextTitle(searchItem.title),
 					type: searchItem.type,
 					url: searchItem.url,
-					embedded: searchItem._embedded,
+					...(includeEmbeds ? { embedded: searchItem._embedded } : {}),
 				};
 				break;
 		}
@@ -214,6 +222,7 @@ interface FetchSearchResultsArgs {
 	queryFilter: QueryFilter;
 	queryFieldsFilter?: QueryFieldsFilter;
 	searchResultFilter?: SearchResultFilter;
+	includeEmbeds?: boolean;
 	excludeItems: Array<IdentifiableObject>;
 	signal?: AbortSignal;
 }
@@ -227,6 +236,7 @@ export async function fetchSearchResults({
 	queryFilter,
 	queryFieldsFilter,
 	searchResultFilter,
+	includeEmbeds,
 	excludeItems,
 	signal,
 }: FetchSearchResultsArgs) {
@@ -238,6 +248,7 @@ export async function fetchSearchResults({
 		contentTypes,
 		queryFilter,
 		queryFieldsFilter,
+		includeEmbeds,
 	});
 	const response = await apiFetch<Response>({
 		path: searchQueryString,
@@ -261,7 +272,13 @@ export async function fetchSearchResults({
 			break;
 	}
 
-	const normalizedResults = normalizeResults({ results, excludeItems, mode, searchResultFilter });
+	const normalizedResults = normalizeResults({
+		results,
+		excludeItems,
+		mode,
+		searchResultFilter,
+		includeEmbeds,
+	});
 
 	const hasNextPage = totalPages > page;
 	const hasPreviousPage = page > 1;

--- a/cypress/integration/ContentPicker.spec.js
+++ b/cypress/integration/ContentPicker.spec.js
@@ -13,8 +13,18 @@ context('ContentPicker', () => {
 
 	it('allows the user to see results when on focus', () => {
 		cy.createPost({title: 'Post Picker'});
-		cy.insertBlock('Hello World');
-		cy.get('.wp-block-example-hello-world .components-text-control__input').focus();
+		cy.insertBlock('Content Picker');
+		cy.get('.wp-block-example-content-picker .components-input-control__input').focus();
 		cy.get('.tenup-content-search-list').should('exist');
+	})
+
+	it('displays the post date in the search results', () => {
+		cy.createPost({title: 'Post Picker with Post Date'});
+		cy.insertBlock('Content Picker');
+		cy.get('.wp-block-example-content-picker .components-input-control__input').focus();
+		cy.get('.tenup-content-search-list .tenup-content-search-list-item time').invoke('attr', 'datetime').then((datetime) => {
+			const date = new Date(datetime);
+			expect(date.toString()).to.not.equal('Invalid Date');
+		});
 	})
 })

--- a/cypress/integration/ContentSearch.spec.js
+++ b/cypress/integration/ContentSearch.spec.js
@@ -14,7 +14,17 @@ context('ContentSearch', () => {
 	it('allows the user to see initial results on focus', () => {
 		cy.createPost({title: 'Post Searcher with fetchOnFocus'});
 		cy.insertBlock('Post Searcher');
-		cy.get('.wp-block-example-content-search .components-text-control__input').focus();
+		cy.get('.wp-block-example-content-search .components-input-control__input').focus();
 		cy.get('.tenup-content-search-list').should('exist');
+	})
+
+	it('displays the post date in the search results', () => {
+		cy.createPost({title: 'Post Searcher with Post Date'});
+		cy.insertBlock('Post Searcher');
+		cy.get('.wp-block-example-content-search .components-input-control__input').focus();
+		cy.get('.tenup-content-search-list .tenup-content-search-list-item time').invoke('attr', 'datetime').then((datetime) => {
+			const date = new Date(datetime);
+			expect(date.toString()).to.not.equal('Invalid Date');
+		});
 	})
 })

--- a/example/src/blocks/content-picker-example/edit.tsx
+++ b/example/src/blocks/content-picker-example/edit.tsx
@@ -20,7 +20,7 @@ const renderItemType = ( props ) => {
 		<>
 			{ subtype ? subtype : type }
 			<br />
-			<small>{ postDate.toLocaleDateString() }</small>
+			<time datetime={ postDate.toISOString() }>{ postDate.toLocaleDateString() }</time>
 		</>
 	);
 };

--- a/example/src/blocks/content-picker-example/edit.tsx
+++ b/example/src/blocks/content-picker-example/edit.tsx
@@ -3,8 +3,27 @@ import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, Placeholder } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 
 import { ContentPicker } from '@10up/block-components';
+
+/**
+ * Example search result customization that uses embedded data to display the
+ * post date.
+ */
+const renderItemType = ( props ) => {
+	const { type, subtype, embedded } = props;
+	const { date } = embedded?.self?.[ 0 ] ?? {};
+	const postDate = new Date( Date.parse( date ) );
+
+	return (
+		<>
+			{ subtype ? subtype : type }
+			<br />
+			<small>{ postDate.toLocaleDateString() }</small>
+		</>
+	);
+};
 
 export const BlockEdit = (props) => {
 	const {
@@ -35,36 +54,44 @@ export const BlockEdit = (props) => {
 
 	const blockProps = useBlockProps();
 
+	/**
+	 * Example query string filter that returns results in reverse chronological
+	 * order.
+	 */
+	const queryFilter = ( query ) => {
+		return addQueryArgs( query, {
+			orderby: 'date',
+			order: 'desc',
+		} );
+	};
+
+	const ContentPickerControl = () => (
+		<ContentPicker
+			label={__('Select a Post or Page', 'example')}
+			contentTypes={['page', 'post']}
+			onPickChange={handlePostSelection}
+			content={selectedPosts}
+			maxContentItems={5}
+			queryFilter={queryFilter}
+			queryFieldsFilter={queryFieldsFilter}
+			searchResultFilter={searchResultFilter}
+			pickedItemFilter={pickedItemFilter}
+			includeEmbeds="self"
+			renderItemType={renderItemType}
+			fetchInitialResults
+		/>
+	);
+
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={__('Content Picker', 'example')}>
-					<ContentPicker
-						label={__('Select a Post or Page', 'example')}
-						contentTypes={['page', 'post']}
-						onPickChange={handlePostSelection}
-						fetchInitialResults
-						content={selectedPosts}
-						maxContentItems={5}
-						queryFieldsFilter={queryFieldsFilter}
-						searchResultFilter={searchResultFilter}
-						pickedItemFilter={pickedItemFilter}
-					/>
+					<ContentPickerControl />
 				</PanelBody>
 			</InspectorControls>
 			<div {...blockProps}>
 				<Placeholder label={__('Content Picker', 'example')} instructions={__('Use the text field to search for a post', 'example')}>
-					<ContentPicker
-						label={__('Select a Post or Page', 'example')}
-						contentTypes={['page', 'post']}
-						onPickChange={handlePostSelection}
-						fetchInitialResults
-						content={selectedPosts}
-						maxContentItems={5}
-						queryFieldsFilter={queryFieldsFilter}
-						searchResultFilter={searchResultFilter}
-						pickedItemFilter={pickedItemFilter}
-					/>
+					<ContentPickerControl />
 				</Placeholder>
 			</div>
 		</>

--- a/example/src/blocks/content-search-example/edit.tsx
+++ b/example/src/blocks/content-search-example/edit.tsx
@@ -20,7 +20,7 @@ const renderItemType = ( props ) => {
 		<>
 			{ subtype ? subtype : type }
 			<br />
-			<small>{ postDate.toLocaleDateString() }</small>
+			<time datetime={ postDate.toISOString() }>{ postDate.toLocaleDateString() }</time>
 		</>
 	);
 };

--- a/example/src/blocks/content-search-example/edit.tsx
+++ b/example/src/blocks/content-search-example/edit.tsx
@@ -3,8 +3,27 @@ import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, Placeholder } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 
 import { ContentSearch } from '@10up/block-components';
+
+/**
+ * Example search result customization that uses embedded data to display the
+ * post date.
+ */
+const renderItemType = ( props ) => {
+	const { type, subtype, embedded } = props;
+	const { date } = embedded?.self?.[ 0 ] ?? {};
+	const postDate = new Date( Date.parse( date ) );
+
+	return (
+		<>
+			{ subtype ? subtype : type }
+			<br />
+			<small>{ postDate.toLocaleDateString() }</small>
+		</>
+	);
+};
 
 export const BlockEdit = (props) => {
 	const {
@@ -33,36 +52,45 @@ export const BlockEdit = (props) => {
 
 	const blockProps = useBlockProps();
 
+	/**
+	 * Example query string filter that returns results in reverse chronological
+	 * order.
+	 */
+	const queryFilter = ( query ) => {
+		return addQueryArgs( query, {
+			orderby: 'date',
+			order: 'desc',
+		} );
+	};
+
+	const ContentSearchControl = () => (
+		<ContentSearch
+			label={__('Select a Post or Page', 'example')}
+			contentTypes={['page', 'post']}
+			onSelectItem={handlePostSelection}
+			queryFilter={queryFilter}
+			queryFieldsFilter={queryFieldsFilter}
+			searchResultFilter={searchResultFilter}
+			renderItemType={renderItemType}
+			fetchInitialResults
+		/>
+	);
+
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={__('Post Searcher', 'example')}>
-					<ContentSearch
-						label={__('Select a Post or Page', 'example')}
-						contentTypes={['page', 'post']}
-						onSelectItem={handlePostSelection}
-						fetchInitialResults
-						queryFieldsFilter={queryFieldsFilter}
-						searchResultFilter={searchResultFilter}
-					/>
+					<ContentSearchControl />
 				</PanelBody>
 			</InspectorControls>
 			<div {...blockProps}>
 				<Placeholder label={__('Post Searcher', 'example')} instructions={__('Use the text field to search for a post', 'example')}>
-				<div>
-						{
-							selectedPost &&
+					<div>
+						{ selectedPost && (
 							<p>{__('Selected Post:', 'example')} {selectedPost.title}</p>
-						}
+						) }
 					</div>
-					<ContentSearch
-						label={__('Select a Post or Page', 'example')}
-						contentTypes={['page', 'post']}
-						onSelectItem={handlePostSelection}
-						fetchInitialResults
-						queryFieldsFilter={queryFieldsFilter}
-						searchResultFilter={searchResultFilter}
-					/>
+					<ContentSearchControl />
 				</Placeholder>
 			</div>
 		</>

--- a/example/src/blocks/content-search-example/edit.tsx
+++ b/example/src/blocks/content-search-example/edit.tsx
@@ -71,7 +71,7 @@ export const BlockEdit = (props) => {
 			queryFilter={queryFilter}
 			queryFieldsFilter={queryFieldsFilter}
 			searchResultFilter={searchResultFilter}
-			includeEmbeds
+			includeEmbeds="self"
 			renderItemType={renderItemType}
 			fetchInitialResults
 		/>

--- a/example/src/blocks/content-search-example/edit.tsx
+++ b/example/src/blocks/content-search-example/edit.tsx
@@ -71,6 +71,7 @@ export const BlockEdit = (props) => {
 			queryFilter={queryFilter}
 			queryFieldsFilter={queryFieldsFilter}
 			searchResultFilter={searchResultFilter}
+			includeEmbeds
 			renderItemType={renderItemType}
 			fetchInitialResults
 		/>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This PR allows for control over whether the search results in the `ContentSearch` component should include embeddings in the response via the new `includeEmbeds` prop and passes that `embedded` object through the `NormalizedSearchResults` to the `renderItem` and `renderItemType` functions.

This allows for greater customization of the search results than what is currently provided in the normalized results without needing to perform additional API requests. This allows any standard field included in an embedded response to be used, enabling things like showing the publish date for instance.

The ContentSearch and ContentPicker components have been updated to accept the `includeEmbeds` prop, as well as the `QueryArgs` interface. Both the `content-search-example` and `content-picker-example` blocks have been updated to demonstrate result customization.

Here is the content search example that has been updated to include the post date:

<img width="664" height="343" alt="Screenshot 2025-09-15 at 1 57 33 PM" src="https://github.com/user-attachments/assets/c7bbfef1-d8ed-4472-be77-541675a0c418" />


Note that `_embed: true` is [currently part of the post search query](https://github.com/10up/block-components/blob/ead84568b8bab317d3abe7a44a0d9d7d8b674a39/components/content-search/utils.ts#L62) but the embeds are not passed through, both because `normalizeResults` does not currently process it but also because the fields requested don't allow for `_links` and `_embedded` in the response. This change controls both of these aspects, and by default does not include embeds.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #395

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Verify that both the content search and content picker example blocks display publish date under the type label
2. Verify that both components work as they did before the change when `includeEmbeds` is not passed

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New `includeEmbeds` prop for `ContentSearch` and `ContentPicker` components

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @cr0ybot

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.

I'm opening the PR for review because I'm admittedly new to cypress and I'm not sure how to run the integration tests, but the tests have been updated (I don't think they would have been working before).