### PR TITLE
Feature: Allow passing all Button Props through ClipboardButton component

### DIFF
--- a/components/clipboard-button/index.tsx
+++ b/components/clipboard-button/index.tsx
@@ -1,28 +1,25 @@
-import { useCopyToClipboard } from '@wordpress/compose';
+import { useCopyToClipboard, useMergeRefs } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-interface ClipboardButtonProps {
+type ButtonProps = React.ComponentProps<typeof Button>;
+
+interface ClipboardButtonProps extends Partial<Omit<ButtonProps, 'children'>> {
 	/**
 	 * The text to copy to the clipboard.
 	 */
 	text: string;
 
 	/**
-	 * Boolean to disable the button.
-	 */
-	disabled: boolean;
-
-	/**
 	 * Function to run when the text is successfully copied.
 	 */
-	onSuccess: Function;
+	onSuccess?: Function;
 
 	/**
 	 * Labels for the button.
 	 */
-	labels: ButtonLabels;
+	labels?: ButtonLabels;
 }
 
 interface ButtonLabels {
@@ -39,9 +36,9 @@ interface ButtonLabels {
 
 export const ClipboardButton: React.FC<ClipboardButtonProps> = ({
 	text = '',
-	disabled = false,
 	onSuccess = () => {},
 	labels = {},
+	...rest
 }) => {
 	const [hasCopied, setHasCopied] = useState(false);
 	const copy = labels.copy ? labels.copy : __('Copy');
@@ -77,9 +74,10 @@ export const ClipboardButton: React.FC<ClipboardButtonProps> = ({
 	}
 
 	const ref = useCopyToClipboard(text, successfullyCopied);
+	const mergedRefs = useMergeRefs([ref, (rest.ref as any) || null]);
 
 	return (
-		<Button disabled={disabled} ref={ref}>
+		<Button {...(rest as any)} ref={mergedRefs}>
 			{hasCopied ? copied : copy}
 		</Button>
 	);


### PR DESCRIPTION
Closes #398 

--- 

This pull request refactors the `ClipboardButton` component to improve its flexibility and integration with other components. The main changes focus on making the button props more extensible, handling refs correctly, and making some props optional.

### Component API improvements

* The `ClipboardButtonProps` interface now extends the base `Button` props (using `Partial<Omit<ButtonProps, 'children'>>`), allowing the component to accept any valid button prop except for `children`. This makes the component more flexible and easier to use in different contexts.
* The `disabled`, `labels`, and `onSuccess` props are now optional, providing sensible defaults and reducing the need for boilerplate when using the component. [[1]](diffhunk://#diff-020423ec95bf4bcd3dcfd974af14d9e9773b0416bdc6aaed261d4caba59df31aL1-R22) [[2]](diffhunk://#diff-020423ec95bf4bcd3dcfd974af14d9e9773b0416bdc6aaed261d4caba59df31aL42-R41)

### Ref handling improvements

* The component now merges refs using `useMergeRefs`, ensuring that both internal and external refs are handled correctly when the button is used in more complex scenarios.

### Usage and rendering changes

* The button now spreads any remaining props (`rest`) onto the underlying `Button` component, further improving extensibility and allowing for easier customization.