### PR TITLE
Update call to getMedia with getEntityRecord

### DIFF
--- a/cypress/e2e/Image.spec.js
+++ b/cypress/e2e/Image.spec.js
@@ -27,8 +27,10 @@ context('Image', () => {
 
         cy.savePost();
 
-		// click on the View Post snackbar item
-		cy.get('.components-snackbar a').click();
+		  // click on the View Post snackbar item
+      cy.get('.components-snackbar a').invoke('removeAttr', 'target').click();
+
+      cy.wait(500);
 
         // return to the editor
         cy.get('a').contains('Edit Page').click();

--- a/hooks/use-media/index.ts
+++ b/hooks/use-media/index.ts
@@ -6,14 +6,14 @@ export function useMedia(id: number) {
 	return useSelect(
 		(select) => {
 			// @ts-ignore-next-line - The type definitions for the core store are incomplete.
-			const { getMedia, isResolving, hasFinishedResolution } = select(coreStore);
+			const { getEntityRecord, isResolving, hasFinishedResolution } = select(coreStore);
 
-			const mediaParameters = [id, { context: 'view' }];
+			const mediaParameters = ['postType', 'attachment', id, { context: 'view' }] as const;
 
 			return {
-				media: getMedia(...mediaParameters),
-				isResolvingMedia: isResolving('getMedia', mediaParameters),
-				hasResolvedMedia: hasFinishedResolution('getMedia', mediaParameters),
+				media: getEntityRecord(...mediaParameters),
+				isResolvingMedia: isResolving('getEntityRecord', mediaParameters),
+				hasResolvedMedia: hasFinishedResolution('getEntityRecord', mediaParameters),
 			};
 		},
 		[id],


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Closes #402 

This change resolves the deprecation notice in the JS console referenced in Issue #402.

### How to test the Change

Before testing the change:

1. Add the Image component to a custom block
2. Add that block to a page you're editing
3. Open the JS console in developer tools
4. Look for the "'getMedia' is deprecated since version 6.9..." warning, you should see it.

After the change:

1. Add the Image component to a custom block
2. Add that block to a page you're editing
3. Open the JS console in developer tools
4. Look for the "'getMedia' is deprecated since version 6.9..." warning, you should _**not**_ see it now
5. Test adding an image via upload and from the Media Library, everything should work as normal

### Changelog Entry

> Changed - Existing functionality for the `useMedia` hook: no longer calls `getMedia` (deprecated), but now calls `getEntityRecord`

### Credits
Props @n8finch

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly (no update needed, hook works as normal)
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change. (no changes
- [x] All new and existing tests pass. (test that do not pass on `develop` still don't pass here, except the Image test, see comment below)
