### PR TITLE
Fix PostDate using browser timezone instead of WordPress site timezone

### DIFF
--- a/components/post-date/index.tsx
+++ b/components/post-date/index.tsx
@@ -39,6 +39,12 @@ interface PostDateProps {
 	format?: string;
 
 	/**
+	 * The timezone to use for formatting.
+	 * When not provided, dateI18n falls back to the WordPress site timezone.
+	 */
+	timezone?: string;
+
+	/**
 	 * Remaining props to pass to the time element.
 	 */
 	[key: string]: unknown;
@@ -47,6 +53,7 @@ interface PostDateProps {
 export const PostDate: React.FC<PostDateProps> = ({
 	placeholder = __('No date set', 'tenup'),
 	format,
+	timezone,
 	...rest
 }) => {
 	const { postId, postType, isEditable } = usePost();
@@ -54,7 +61,6 @@ export const PostDate: React.FC<PostDateProps> = ({
 	const [date, setDate] = useEntityProp('postType', postType, 'date', postId as string);
 	const [siteFormat] = useEntityProp('root', 'site', 'date_format');
 	const settings: DateSettings = getSettings();
-	const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 	const resolvedFormat = format || siteFormat || settings.formats.date;
 

--- a/components/post-date/readme.md
+++ b/components/post-date/readme.md
@@ -23,4 +23,5 @@ function BlockEdit() {
 | ---------- | ----------------- | -------- | -------------------------------------------------------------- |
 | `placeholder` | `string` | `No date set` |  |
 | `format` | `string` |  | Uses the WordPress date format setting of the site |
+| `timezone` | `string` |  | Uses the WordPress site timezone when not provided |
 | `...rest` | `object` | `{}` |  |


### PR DESCRIPTION
### Description of the Change                                                                                            
   
  `PostDate` was hardcoding the browser's timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone` and passing it to
   `dateI18n()`. This overrode the WordPress site's configured timezone, causing the editor to display incorrect timezone
  abbreviations (e.g., WET instead of EST).                                                                                
                                                            
  This PR removes the hardcoded browser timezone and adds an optional `timezone` prop to `PostDate`. When the prop is not  
  provided, `dateI18n()` correctly falls back to the WordPress site timezone from `getSettings()`, which is the expected
  behavior. The prop can still be used to explicitly override the timezone when needed.                                    
                                                            
  Closes #                                                                                                                 
   
  ### How to test the Change                                                                                               
                                                            
  1. Set the WordPress site timezone to `America/New_York` (Settings → General) → the editor should show EST/EDT.          
  2. Pass a `timezone="Europe/London"` prop to `PostDate` → should override to GMT/BST.
  3. Leave the `timezone` prop unset with a UTC site setting → should show UTC.                                            
                                                                                                                           
  ### Changelog Entry                                                                                                      
                                                                                                                           
  > Fixed - `PostDate` now uses the WordPress site timezone instead of the browser timezone when formatting dates.         
   
  ### Credits                                                                                                              
                                                            
  Props @s3rgiosan                                                                                                         
   
  ### Checklist:                                                                                                           
                                                            
  - [x] I agree to follow this project's [**Code of                                                                        
  Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
  - [x] I have updated the documentation accordingly.                                                                      
  - [ ] I have added [Critical Flows, Test Cases, and/or End-to-End                                                        
  Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.