### PR TITLE
feat(rich-text-field): add RichTextField component

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The original import paths are still fully supported and will continue to work as
 - [Optional](./components/optional/)
 - [Repeater](./components/repeater/)
 - [RichTextCharacterLimit](./components/rich-text-character-limit)
+- [RichTextField](./components/rich-text-field)
 
 ### Post related Components
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -24,4 +24,5 @@ export { PostCategoryList } from './post-category-list';
 export { PostPrimaryTerm } from './post-primary-term';
 export { PostPrimaryCategory } from './post-primary-category';
 export { RichTextCharacterLimit, getCharacterCount } from './rich-text-character-limit';
+export { RichTextField } from './rich-text-field';
 export { CircularProgressBar, Counter } from './counter';

--- a/components/rich-text-field/index.tsx
+++ b/components/rich-text-field/index.tsx
@@ -1,0 +1,81 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { RichText } from '@wordpress/block-editor';
+import {
+	SlotFillProvider,
+	// @ts-ignore-next-line - experimental component, no public types.
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+
+interface RichTextFieldProps
+	extends Omit<React.ComponentPropsWithoutRef<typeof RichText>, 'isSelected'> {
+	className?: string;
+}
+
+/**
+ * Drop-in `RichText` field for use outside a block's `edit` context
+ * (e.g. inside `InspectorControls` or a `Modal`).
+ *
+ * Handles the three things `RichText` doesn't get for free outside a block:
+ *
+ * 1. Local `SlotFillProvider` so the format-toolbar fills (which `RichText`
+ *    routes through `BlockControls`) resolve inside this field instead of
+ *    being captured by the surrounding block's toolbar slot.
+ * 2. `inlineToolbar` so the format toolbar renders as a popover near the caret.
+ * 3. Manual `isSelected` state plus click-outside deselect, ignoring the
+ *    inline toolbar and any popovers it spawns (e.g. the link URL input).
+ */
+export const RichTextField = ({
+	tagName = 'p',
+	className,
+	...richTextProps
+}: RichTextFieldProps) => {
+	const [isSelected, setIsSelected] = useState(false);
+	const ref = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (!isSelected) {
+			return undefined;
+		}
+
+		const doc = ref.current?.ownerDocument;
+		if (!doc) {
+			return undefined;
+		}
+
+		const handleMouseDown = (event: MouseEvent) => {
+			const target = event.target as HTMLElement | null;
+			if (ref.current?.contains(target)) {
+				return;
+			}
+			if (target?.closest?.('.block-editor-rich-text__inline-format-toolbar')) {
+				return;
+			}
+			if (target?.closest?.('.components-popover')) {
+				return;
+			}
+			setIsSelected(false);
+		};
+
+		doc.addEventListener('mousedown', handleMouseDown);
+		return () => doc.removeEventListener('mousedown', handleMouseDown);
+	}, [isSelected]);
+
+	return (
+		<SlotFillProvider>
+			<HStack
+				ref={ref}
+				className={className}
+				onFocus={() => setIsSelected(true)}
+				expanded
+			>
+				<RichText
+					tagName={tagName}
+					isSelected={isSelected}
+					inlineToolbar
+					{...richTextProps}
+				/>
+			</HStack>
+		</SlotFillProvider>
+	);
+};

--- a/components/rich-text-field/index.tsx
+++ b/components/rich-text-field/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
 import { RichText } from '@wordpress/block-editor';
 import {
 	SlotFillProvider,
@@ -31,35 +32,34 @@ export const RichTextField = ({
 	...richTextProps
 }: RichTextFieldProps) => {
 	const [isSelected, setIsSelected] = useState(false);
-	const ref = useRef<HTMLDivElement | null>(null);
 
-	useEffect(() => {
-		if (!isSelected) {
-			return undefined;
-		}
-
-		const doc = ref.current?.ownerDocument;
-		if (!doc) {
-			return undefined;
-		}
-
-		const handleMouseDown = (event: MouseEvent) => {
-			const target = event.target as HTMLElement | null;
-			if (ref.current?.contains(target)) {
-				return;
+	const ref = useRefEffect<HTMLDivElement>(
+		(node) => {
+			if (!isSelected) {
+				return undefined;
 			}
-			if (target?.closest?.('.block-editor-rich-text__inline-format-toolbar')) {
-				return;
-			}
-			if (target?.closest?.('.components-popover')) {
-				return;
-			}
-			setIsSelected(false);
-		};
 
-		doc.addEventListener('mousedown', handleMouseDown);
-		return () => doc.removeEventListener('mousedown', handleMouseDown);
-	}, [isSelected]);
+			const doc = node.ownerDocument;
+
+			const handleMouseDown = (event: MouseEvent) => {
+				const target = event.target as HTMLElement | null;
+				if (node.contains(target)) {
+					return;
+				}
+				if (target?.closest?.('.block-editor-rich-text__inline-format-toolbar')) {
+					return;
+				}
+				if (target?.closest?.('.components-popover')) {
+					return;
+				}
+				setIsSelected(false);
+			};
+
+			doc.addEventListener('mousedown', handleMouseDown);
+			return () => doc.removeEventListener('mousedown', handleMouseDown);
+		},
+		[isSelected],
+	);
 
 	return (
 		<SlotFillProvider>

--- a/components/rich-text-field/readme.md
+++ b/components/rich-text-field/readme.md
@@ -1,0 +1,75 @@
+# Rich Text Field
+
+A drop-in wrapper around `RichText` for use **outside** a block's `edit` context — for example, inside `InspectorControls` or a `Modal`.
+
+`RichTextField` accepts all the same props as `RichText`, minus `isSelected` (managed internally). Please refer to the [official RichText documentation](https://developer.wordpress.org/block-editor/reference-guides/richtext/).
+
+## Usage
+
+```jsx
+import { InspectorControls } from '@wordpress/block-editor';
+import { Modal, PanelBody, Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { RichTextField } from '@10up/block-components';
+
+function BlockEdit(props) {
+    const { attributes, setAttributes } = props;
+    const { sidebarNote, modalNote } = attributes;
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+        <>
+            <InspectorControls>
+                <PanelBody title={__('Notes', 'your-textdomain')}>
+                    <RichTextField
+                        value={sidebarNote}
+                        onChange={(value) => setAttributes({ sidebarNote: value })}
+                        placeholder={__('Type and select to see the toolbar…', 'your-textdomain')}
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <Button variant="primary" onClick={() => setIsOpen(true)}>
+                {__('Open modal', 'your-textdomain')}
+            </Button>
+
+            {isOpen && (
+                <Modal
+                    title={__('Edit note', 'your-textdomain')}
+                    onRequestClose={() => setIsOpen(false)}
+                >
+                    <RichTextField
+                        value={modalNote}
+                        onChange={(value) => setAttributes({ modalNote: value })}
+                        allowedFormats={['core/bold', 'core/italic', 'core/link']}
+                    />
+                </Modal>
+            )}
+        </>
+    );
+}
+```
+
+## Props
+
+| Name             | Type                       | Default | Description                                                       |
+| ---------------- | -------------------------- | ------- | ----------------------------------------------------------------- |
+| `value`          | `string`                   | —       | HTML string.                                                      |
+| `onChange`       | `(value: string) => void`  | —       | Change handler.                                                   |
+| `tagName`        | `string`                   | `'p'`   | Element rendered by `RichText`.                                   |
+| `placeholder`    | `string`                   | —       | Placeholder text.                                                 |
+| `allowedFormats` | `string[]`                 | —       | Allowed format names (e.g. `['core/bold', 'core/link']`).         |
+| `className`      | `string`                   | —       | Class added to the wrapping element.                              |
+
+All other `RichText` props are forwarded.
+
+## Modal z-index note
+
+When rendering `RichTextField` inside a `Modal`, the inline format toolbar may appear behind the modal. Add this CSS to lift it above the modal:
+
+```css
+body:has(.your-modal-className) .block-editor-rich-text__inline-format-toolbar {
+    z-index: 1000001;
+}
+```


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Adds a new `RichTextField` component: a drop-in wrapper around `RichText` for use **outside** a block's `edit` context (e.g. inside `InspectorControls` or a `Modal`).

`RichText` only works correctly inside a block's `edit` because the surrounding block-editor infrastructure provides a `SlotFillProvider`, a block-selection store, and a `BlockControls` slot for the format toolbar. When rendered outside that context, the format toolbar disappears, selection state is missing, and formatting fills get captured by the parent block's toolbar.

`RichTextField` solves this by providing:

1. A local `SlotFillProvider` so the format toolbar resolves inside the field instead of leaking into the surrounding block's toolbar.
2. `inlineToolbar` so the format toolbar renders as a popover near the caret.
3. Manual `isSelected` state with click-outside deselect that ignores the inline toolbar and any popovers it spawns (e.g. the link URL input).

The component accepts all `RichText` props except `isSelected` (managed internally) and forwards everything else through.

Files added/changed:
- `components/rich-text-field/index.tsx` — component implementation (TypeScript).
- `components/rich-text-field/readme.md` — usage, props, and modal `z-index` note.
- `components/index.ts` — export `RichTextField`.
- `README.md` — list the new component.

Closes #

### How to test the Change

1. `npm install && npm run build` in this repo.
2. In a consumer plugin/theme, import the component:
   ```jsx
   import { RichTextField } from '@10up/block-components';
   ```
3. Use inside a block's `InspectorControls` panel:
   ```jsx
   <InspectorControls>
       <PanelBody title="Notes">
           <RichTextField
               value={attributes.note}
               onChange={(note) => setAttributes({ note })}
               placeholder="Type and select to see the toolbar…"
           />
       </PanelBody>
   </InspectorControls>
   ```
   - Type text, select it, confirm inline format toolbar appears near the caret.
   - Confirm formatting (bold, italic, link) applies inside the sidebar field, not on the parent block.
   - Click outside the field; confirm the toolbar dismisses.
   - Open the link format, type a URL in the popover; confirm clicking inside the popover does not deselect the field.
4. Repeat the same checks with `RichTextField` rendered inside a `Modal`. If the inline toolbar appears behind the modal, apply the CSS override documented in `components/rich-text-field/readme.md`.
5. Verify `tagName`, `placeholder`, `allowedFormats`, and `className` props all forward correctly.

### Changelog Entry

> Added - `RichTextField` component for using `RichText` outside a block's `edit` context (e.g. `InspectorControls`, `Modal`).

### Credits

Props @s3rgiosan

### Checklist:
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
